### PR TITLE
Fix Queries on Endpoints in v2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ conf/**
 
 *.yaml
 gcloud-config.json
+
+.vscode/**

--- a/src/v1/density/routes.ts
+++ b/src/v1/density/routes.ts
@@ -30,8 +30,8 @@ router.get(
   '/howDense',
   asyncify(async (req, res) => {
     try {
-      if (req.params.id) {
-        res.status(200).send((await db.howDense(req.params.id)).map(v => v.result));
+      if (req.query.id) {
+        res.status(200).send((await db.howDense(req.query.id)).map(v => v.result));
       } else {
         res.status(200).send((await db.howDense()).map(v => v.result));
       }

--- a/src/v1/facilities/routes.ts
+++ b/src/v1/facilities/routes.ts
@@ -24,11 +24,11 @@ router.get(
 
 router.get(
   '/facilityInfo',
-  asyncify(async (req, res) => {
+  asyncify(async (req: express.Request, res: express.Response) => {
     try {
       res
         .status(200)
-        .send((await (req.params.id ? db.facilityInfo(req.params.id) : db.facilityInfo())).map(v => v.result));
+        .send((await (req.query.id ? db.facilityInfo(req.query.id) : db.facilityInfo())).map(v => v.result));
     } catch (err) {
       res.status(400).send(err.message);
     }


### PR DESCRIPTION
When transitioning to TypeScript/v2 I accidentally utilized params instead of queries on the GET endpoints. This pull request fixes that.