### PR TITLE
Date query added

### DIFF
--- a/src/v1/dining/db.ts
+++ b/src/v1/dining/db.ts
@@ -25,23 +25,23 @@ export class DiningDB extends DB {
       let d = date;
       const lowercaseInput = date.toLowerCase();
       const dt = new Date();
-      if (lowercaseInput === "today") {
+      if (lowercaseInput === 'today') {
         d = dt.toISOString().slice(0, 10);
       }
-      else if (lowercaseInput === "tomorrow") {
+      else if (lowercaseInput === 'tomorrow') {
         dt.setDate(dt.getDate() + 1);
         d = dt.toISOString().slice(0, 10);
       }
-      else if (lowercaseInput === "yesterday") {
+      else if (lowercaseInput === 'yesterday') {
         dt.setDate(dt.getDate() - 1);
         d = dt.toISOString().slice(0, 10);
       }
-      if (!isNaN(Date.parse(d))) {
+      if (!Number.isNaN(Date.parse(d))) {
         result = result.map(e =>
           e.weeksMenus.filter(m => m.date === d));
       }
       else {
-        throw new Error("Invalid Date");
+        throw new Error('Invalid Date');
       }
     }
     return [DB.query(result)];

--- a/src/v1/dining/routes.ts
+++ b/src/v1/dining/routes.ts
@@ -24,12 +24,7 @@ export default function routes(redis?: Redis, credentials?) {
     cache(dateKey, redis),
     asyncify(async (req: express.Request, res: express.Response) => {
       try {
-        const menuList = await (
-          req.query.facility ?
-            req.query.date ? db.getMenus(req.query.facility, req.query.date) :
-              db.getMenus(req.query.facility) :
-            req.query.date ? db.getMenus(undefined, req.query.date) :
-              db.getMenus());
+        const menuList = await (db.getMenus(req.query.facility, req.query.date));
         const data = JSON.stringify(menuList.map(v => v.result));
 
         if (redis) {

--- a/src/v1/dining/routes.ts
+++ b/src/v1/dining/routes.ts
@@ -13,14 +13,23 @@ export default function routes(redis?: Redis, credentials?) {
 
   const router = express.Router();
 
-  const menuKey = req => (req.query.facility ? `/menuData?${req.query.facility}` : `/menuData`);
+  const menuKey = req =>
+    (req.query.facility ? `/menuData?${req.query.facility}` : `/menuData`);
+  const dateKey = req =>
+    (req.query.date ? `/menuData?${req.query.date}` : `/menuData`);
 
   router.get(
     '/menuData',
     cache(menuKey, redis),
+    cache(dateKey, redis),
     asyncify(async (req: express.Request, res: express.Response) => {
       try {
-        const menuList = await (req.query.facility ? db.getMenus(req.query.facility) : db.getMenus());
+        const menuList = await (
+          req.query.facility ?
+            req.query.date ? db.getMenus(req.query.facility, req.query.date) :
+              db.getMenus(req.query.facility) :
+            req.query.date ? db.getMenus(undefined, req.query.date) :
+              db.getMenus());
         const data = JSON.stringify(menuList.map(v => v.result));
 
         if (redis) {

--- a/src/v1/facilities/db.ts
+++ b/src/v1/facilities/db.ts
@@ -138,7 +138,7 @@ export class FacilityDB extends DB {
   }
 
   async facilityHours(
-    facilityId?: string, startDate?: string, endDate?: string,
+    facilityId?: string, startDate?: string, endDate?: string
   ): Promise<DBQuery<string, FacilityHours>[]> {
     const { datastore } = this;
     const query = datastore.createQuery('development-testing-hours');

--- a/src/v1/server.ts
+++ b/src/v1/server.ts
@@ -10,7 +10,7 @@ import Auth, { authenticated } from './auth';
 export default function routes(redis?: Redis, credentials?) {
   const router = express.Router();
 
-  // router.use('/', authenticated);
+  router.use('/', authenticated);
   router.use('/', densityRoutes(redis, credentials));
   router.use('/', facilityRoutes(redis, credentials));
   router.use('/', diningRoutes(redis, credentials));

--- a/src/v1/server.ts
+++ b/src/v1/server.ts
@@ -10,7 +10,7 @@ import Auth, { authenticated } from './auth';
 export default function routes(redis?: Redis, credentials?) {
   const router = express.Router();
 
-  router.use('/', authenticated);
+  // router.use('/', authenticated);
   router.use('/', densityRoutes(redis, credentials));
   router.use('/', facilityRoutes(redis, credentials));
   router.use('/', diningRoutes(redis, credentials));


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request contributes additional backend functionality to parse the json returned by flux-functions.

- [x] cleaned up code for receiving queries
- [x] added `date` query

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Execute `npm run dev` and test in Postman/browser.
`http://localhost:3333/v1/menuData?facility=becker&date=2019-11-20`  
`http://localhost:3333/v1/menuData?date=2019-11-20`  
`http://localhost:3333/v1/menuData?date=today`

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

The date query must be in ISO format `YYYY-MM-DD`, `yesterday`, `today`, or `tomorrow`. There is an error if the date is untranslatable but no error if there are no menus found for the date; the frontend should check if the returned json is empty.
