### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto


### PR DESCRIPTION
### Summary

Add .gitattributes so that git can perform line-ending normalization. This can avoid a huge diff that simply changes the line-ending for all files.

### Test Plan

Read the relevant [docs](https://git-scm.com/docs/gitattributes#Documentation/gitattributes.txt-Settostringvalueauto).