### PR TITLE
Facility and historical data endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1143,9 +1143,9 @@
       }
     },
     "@types/bytebuffer": {
-      "version": "5.0.40",
-      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
-      "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
+      "version": "5.0.41",
+      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.41.tgz",
+      "integrity": "sha512-Mdrv4YcaHvpkx25ksqqFaezktx3yZRcd51GZY0rY/9avyaqZdiT/GiWRhfrJhMpgzXqTOSHgGvsumGxJFNiZZA==",
       "requires": {
         "@types/long": "*",
         "@types/node": "*"
@@ -1249,6 +1249,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
+    },
+    "@types/moment-timezone": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.13.tgz",
+      "integrity": "sha512-SWk1qM8DRssS5YR9L4eEX7WUhK/wc96aIr4nMa6p0kTk9YhGGOJjECVhIdPEj13fvJw72Xun69gScXSZ/UmcPg==",
+      "dev": true,
+      "requires": {
+        "moment": ">=2.14.0"
+      }
     },
     "@types/node": {
       "version": "11.15.7",
@@ -1382,6 +1391,11 @@
           "dev": true
         }
       }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -1639,6 +1653,20 @@
             "regex-cache": "^0.4.2"
           }
         }
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -2917,6 +2945,11 @@
         }
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "ci-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
@@ -3270,6 +3303,11 @@
       "integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
       "dev": true
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -3473,8 +3511,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3537,6 +3574,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "denque": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
@@ -3560,6 +3602,11 @@
       "requires": {
         "repeating": "^2.0.0"
       }
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "dicer": {
       "version": "0.3.0",
@@ -4971,6 +5018,14 @@
         "universalify": "^0.1.0"
       }
     },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5540,6 +5595,21 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
     "gaxios": {
       "version": "1.8.4",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.8.4.tgz",
@@ -5950,308 +6020,18 @@
       "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
     },
     "grpc": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
-      "integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.3.tgz",
+      "integrity": "sha512-EDemzuZTfhM0hgrXqC4PtR76O3t+hTIYJYR5vgiW0yt2WJqo4mhxUqZUirzUQz34Psz7dbLp38C6Cl7Ij2vXRQ==",
       "requires": {
         "@types/bytebuffer": "^5.0.40",
         "lodash.camelcase": "^4.3.0",
         "lodash.clone": "^4.5.0",
         "nan": "^2.13.2",
-        "node-pre-gyp": "^0.14.0",
+        "node-pre-gyp": "^0.15.0",
         "protobufjs": "^5.0.3"
       },
       "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "debug": {
-          "version": "3.2.6",
-          "bundled": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "fs-minipass": {
-          "version": "1.2.7",
-          "bundled": true,
-          "requires": {
-            "minipass": "^2.6.0"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.4",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.3",
-          "bundled": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "minipass": {
-          "version": "2.9.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.3.3",
-          "bundled": true,
-          "requires": {
-            "minipass": "^2.9.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            }
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "needle": {
-          "version": "2.4.0",
-          "bundled": true,
-          "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.14.0",
-          "bundled": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4.4.2"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "npm-packlist": {
-          "version": "1.4.6",
-          "bundled": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "bundled": true
-        },
         "protobufjs": {
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
@@ -6262,119 +6042,6 @@
             "glob": "^7.0.5",
             "yargs": "^3.10.0"
           }
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "bundled": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "tar": {
-          "version": "4.4.13",
-          "bundled": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "bundled": true
         }
       }
     },
@@ -6486,6 +6153,11 @@
       "requires": {
         "has-symbol-support-x": "^1.4.1"
       }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -6674,6 +6346,14 @@
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -6741,8 +6421,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "7.1.0",
@@ -8112,6 +7791,23 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "requires": {
+        "minipass": "^2.9.0"
+      }
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -8135,7 +7831,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       },
@@ -8143,8 +7838,7 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -8155,9 +7849,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
     },
     "moment-timezone": {
       "version": "0.5.28",
@@ -8218,6 +7912,31 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "needle": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
+      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -8286,6 +8005,32 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
       "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
     },
+    "node-pre-gyp": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
+      "integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.3",
+        "needle": "^2.5.0",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4.4.2"
+      }
+    },
+    "nopt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -8326,6 +8071,29 @@
         }
       }
     },
+    "npm-bundled": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -8333,6 +8101,17 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -10632,8 +10411,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -10837,8 +10615,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "1.4.0",
@@ -10851,8 +10628,16 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-cancelable": {
       "version": "0.4.1",
@@ -11505,7 +11290,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -11516,8 +11300,7 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -11947,7 +11730,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -11993,6 +11775,11 @@
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
       "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "5.7.1",
@@ -12075,8 +11862,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -12556,8 +12342,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "stubs": {
       "version": "3.0.0",
@@ -12714,6 +12499,20 @@
             "ansi-regex": "^4.1.0"
           }
         }
+      }
+    },
+    "tar": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
       }
     },
     "teeny-request": {
@@ -13302,6 +13101,14 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
     },
     "widest-line": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "firebase-admin": "^7.0.0",
     "ioredis": "^4.16.0",
     "jwks-rsa": "^1.7.0",
-    "moment": "^2.22.2",
+    "moment": "^2.27.0",
     "moment-timezone": "^0.5.28",
     "passport": "^0.4.1",
     "redis": "^3.0.2",
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "2.3.5",
+    "@types/moment-timezone": "^0.5.13",
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",
     "eslint": "^6.8.0",

--- a/src/v1/facilities/db.ts
+++ b/src/v1/facilities/db.ts
@@ -1,19 +1,24 @@
-import * as moment from 'moment-timezone'
-import { firebaseDB } from '../auth';
-import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from '../mapping';
-import { FacilityHourSet, FacilityInfo } from './models/info';
-import { CampusLocation } from '../models/campus';
-import { DBQuery, DB, DatabaseQueryNoParams } from '../db';
-import { FacilityMetadata } from './models/list';
-import { FacilityHours, DailyHours } from './models/hours';
+import { firebaseDB } from "../auth";
+import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from "../mapping";
+import { FacilityHourSet, FacilityInfo } from "./models/info";
+import { CampusLocation } from "../models/campus";
+import { DBQuery, DB, DatabaseQueryNoParams } from "../db";
+import { FacilityMetadata } from "./models/list";
+import { FacilityHours, DailyHours } from "./models/hours";
+import moment = require("moment");
+require("moment-timezone");
+
+moment.tz.setDefault("America/New_York");
 
 function getInfo(id: string, hours: FacilityInfoDocument[]): FacilityInfo {
   const date = Math.floor(Date.now() / 1000);
 
-  const facilityHours: FacilityInfoDocument = hours.find(x => x.id === id);
+  const facilityHours: FacilityInfoDocument = hours.find((x) => x.id === id);
 
   if (facilityHours && facilityHours.operatingHours) {
-    const nextClosing = facilityHours.operatingHours.find(e => e.startTimestamp < date && e.endTimestamp > date);
+    const nextClosing = facilityHours.operatingHours.find(
+      (e) => e.startTimestamp < date && e.endTimestamp > date
+    );
 
     const nextClosingTimestamp = nextClosing ? nextClosing.endTimestamp : -1;
 
@@ -23,7 +28,8 @@ function getInfo(id: string, hours: FacilityInfoDocument[]): FacilityInfo {
       // TODO This is broken. Needs to find last opening, not first opening.
       // TODO This may be fixed now... test this.
       nextOpen = facilityHours.operatingHours.reduce(
-        (previous, current) => (current.startTimestamp > previous.startTimestamp ? current : previous),
+        (previous, current) =>
+          current.startTimestamp > previous.startTimestamp ? current : previous,
         FacilityHourSet.assign({ startTimestamp: 0, endTimestamp: 0 })
       );
     }
@@ -35,35 +41,40 @@ function getInfo(id: string, hours: FacilityInfoDocument[]): FacilityInfo {
       isOpen: nextClosingTimestamp !== -1,
       description: facilityHours.description,
       closingAt: nextClosingTimestamp,
-      dailyHours: facilityHours.operatingHours
+      dailyHours: facilityHours.operatingHours,
     });
   }
   return null;
 }
 
-function getHoursInfo(id: string, hours: FacilityHoursDocument[], startDate: string, endDate: string): FacilityHours {
+function getHoursInfo(
+  id: string,
+  hours: FacilityHoursDocument[],
+  startDate: string,
+  endDate: string
+): FacilityHours {
   // need to go through hours and find those between specified start and end date
   // in the DailyHours object we create, we will have a FacilityHourSet[]. We will create a new DailyHours object
   // for every date in the range, and in the FacilityHourSet[] for each of these DailyHours objects, we put
   // all time ranges for that given date.
   // Add all the DailyHours objects to an array, and return a FacilityHours object where hours is assigned to this
   // array.
-  const dateBegin = moment(startDate, 'MM-DD-YY').tz('America/New_York').unix()
-  const dateEnd = moment(endDate, 'MM-DD-YY').tz('America/New_York').unix()
+  const dateBegin = moment(startDate);
+  const dateEnd = moment(endDate);
   const facilityId = id;
-  const validDailyHours = []
+  const validDailyHours: DailyHours[] = [];
   for (const doc of hours) {
     if (doc.id === id) {
       for (const facilityHours of doc.hours) {
-        if (dateBegin <= moment(facilityHours.date, 'YYYY-MM-DD').tz('America/New_York').unix()
-          && dateEnd >= moment(facilityHours.date, 'YYYY-MM-DD').tz('America/New_York').unix()) {
+        const facilityDate = moment(facilityHours.date);
+        if (dateBegin <= facilityDate && dateEnd >= facilityDate) {
           validDailyHours.push(
             DailyHours.assign({
               date: facilityHours.date,
               dayOfWeek: facilityHours.dayOfWeek,
               status: facilityHours.status,
               statusText: facilityHours.statusText,
-              dailyHours: facilityHours.dailyHours
+              dailyHours: facilityHours.dailyHours,
             })
           );
         }
@@ -72,7 +83,7 @@ function getHoursInfo(id: string, hours: FacilityHoursDocument[], startDate: str
   }
   return FacilityHours.assign({
     id: facilityId,
-    hours: validDailyHours
+    hours: validDailyHours,
   });
 }
 
@@ -93,31 +104,29 @@ export class FacilityDB extends DB {
     super(datastore);
   }
 
-  async facilityInfo(facilityId?: string): Promise<DBQuery<string, FacilityInfo>[]> {
+  async facilityInfo(
+    facilityId?: string
+  ): Promise<DBQuery<string, FacilityInfo>[]> {
     const { datastore } = this;
-
-    const query = datastore.createQuery('hours');
+    const query = datastore.createQuery("hours");
 
     try {
       const [hours] = await datastore.runQuery(query);
 
       if (facilityId) {
         const id = facilityId;
-
         if (id in ID_MAP) {
           const info = getInfo(id, hours);
-
           if (info) {
             return [DB.query(info, id)];
           }
         }
-
         throw new Error(`Invalid ID: ${id}`);
       } else {
         return Object.keys(ID_MAP)
-          .map(id => getInfo(id, hours))
-          .filter(obj => obj != null)
-          .map(info => DB.query(info));
+          .map((id) => getInfo(id, hours))
+          .filter((obj) => obj != null)
+          .map((info) => DB.query(info));
       }
     } catch (err) {
       console.log(err.message);
@@ -125,14 +134,16 @@ export class FacilityDB extends DB {
     }
   }
 
-  async facilityList(facilityListType):
-  /* eslint-disable-line class-methods-use-this */ Promise<
-    DatabaseQueryNoParams<FacilityMetadata>[]> {
-    return Object.keys(facilityListType).map(key =>
+  async facilityList(
+    facilityListType
+  ): /* eslint-disable-line class-methods-use-this */ Promise<
+    DatabaseQueryNoParams<FacilityMetadata>[]
+  > {
+    return Object.keys(facilityListType).map((key) =>
       DB.query(
         FacilityMetadata.assign({
           displayName: facilityListType[key],
-          id: key
+          id: key,
         })
       )
     );
@@ -140,34 +151,36 @@ export class FacilityDB extends DB {
 
   // Should I just go ahead and delete these then
   async efacilityList(): /* eslint-disable-line class-methods-use-this */ Promise<
-    DatabaseQueryNoParams<FacilityMetadata>[]> {
-    return Object.keys(DISPLAY_MAP).map(key =>
+    DatabaseQueryNoParams<FacilityMetadata>[]
+  > {
+    return Object.keys(DISPLAY_MAP).map((key) =>
       DB.query(
         FacilityMetadata.assign({
           displayName: DISPLAY_MAP[key],
-          id: key
+          id: key,
         })
       )
     );
   }
 
-  async gymFacilityList(): Promise<
-    DatabaseQueryNoParams<FacilityMetadata>[]> {
-    return Object.keys(GYM_DISPLAY_MAP).map(key =>
+  async gymFacilityList(): Promise<DatabaseQueryNoParams<FacilityMetadata>[]> {
+    return Object.keys(GYM_DISPLAY_MAP).map((key) =>
       DB.query(
         FacilityMetadata.assign({
           displayName: DISPLAY_MAP[key],
-          id: key
+          id: key,
         })
       )
     );
   }
 
   async facilityHours(
-    facilityId?: string, startDate?: string, endDate?: string
+    facilityId?: string,
+    startDate?: string,
+    endDate?: string
   ): Promise<DBQuery<string, FacilityHours>[]> {
     const { datastore } = this;
-    const query = datastore.createQuery('development-testing-hours');
+    const query = datastore.createQuery("development-testing-hours");
     try {
       const [hoursrange] = await datastore.runQuery(query);
       if (facilityId) {
@@ -179,42 +192,40 @@ export class FacilityDB extends DB {
             if (hoursInfo) {
               return [DB.query(hoursInfo, id)];
             }
-          }
-          else {
+          } else {
             throw new Error(`Invalid ID`);
           }
-        }
-        else {
+        } else {
           throw new Error(`Missing start and/or end date`);
         }
-      }
-      else {
+      } else {
         if (startDate && endDate) {
           return Object.keys(ID_MAP)
-            .map(id => getHoursInfo(id, hoursrange, startDate, endDate))
-            .filter(obj => obj != null)
-            .map(info => DB.query(info));
+            .map((id) => getHoursInfo(id, hoursrange, startDate, endDate))
+            .filter((obj) => obj != null)
+            .map((info) => DB.query(info));
         }
         throw new Error(`Missing start and/or end date`);
       }
       throw new Error(`Need to include dates and facility id`);
-    }
-    catch (err) {
+    } catch (err) {
       throw new Error(err.message);
     }
   }
 
   async gymFacilityHours(facilityId?: string, date?: string) {
     if (facilityId) {
-      return (await firebaseDB.collection('gymdata').doc(facilityId).get()).data();
+      return (
+        await firebaseDB.collection("gymdata").doc(facilityId).get()
+      ).data();
     }
-    const data = []
-    const queryResult = await firebaseDB.collection('gymdata').get()
+    const data = [];
+    const queryResult = await firebaseDB.collection("gymdata").get();
     for (const doc of queryResult.docs) {
       const docData = doc.data();
-      docData.id = doc.id
-      data.push(docData)
+      docData.id = doc.id;
+      data.push(docData);
     }
-    return data
+    return data;
   }
 }

--- a/src/v1/facilities/db.ts
+++ b/src/v1/facilities/db.ts
@@ -1,23 +1,24 @@
-import { firebaseDB } from "../auth";
-import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from "../mapping";
-import { FacilityHourSet, FacilityInfo } from "./models/info";
-import { CampusLocation } from "../models/campus";
-import { DBQuery, DB, DatabaseQueryNoParams } from "../db";
-import { FacilityMetadata } from "./models/list";
-import { FacilityHours, DailyHours } from "./models/hours";
-import moment = require("moment");
-require("moment-timezone");
+import { firebaseDB } from '../auth';
+import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from '../mapping';
+import { FacilityHourSet, FacilityInfo } from './models/info';
+import { CampusLocation } from '../models/campus';
+import { DBQuery, DB, DatabaseQueryNoParams } from '../db';
+import { FacilityMetadata } from './models/list';
+import { FacilityHours, DailyHours } from './models/hours';
 
-moment.tz.setDefault("America/New_York");
+import moment = require('moment');
+require('moment-timezone');
+
+moment.tz.setDefault('America/New_York');
 
 function getInfo(id: string, hours: FacilityInfoDocument[]): FacilityInfo {
   const date = Math.floor(Date.now() / 1000);
 
-  const facilityHours: FacilityInfoDocument = hours.find((x) => x.id === id);
+  const facilityHours: FacilityInfoDocument = hours.find(x => x.id === id);
 
   if (facilityHours && facilityHours.operatingHours) {
     const nextClosing = facilityHours.operatingHours.find(
-      (e) => e.startTimestamp < date && e.endTimestamp > date
+      e => e.startTimestamp < date && e.endTimestamp > date
     );
 
     const nextClosingTimestamp = nextClosing ? nextClosing.endTimestamp : -1;
@@ -41,7 +42,7 @@ function getInfo(id: string, hours: FacilityInfoDocument[]): FacilityInfo {
       isOpen: nextClosingTimestamp !== -1,
       description: facilityHours.description,
       closingAt: nextClosingTimestamp,
-      dailyHours: facilityHours.operatingHours,
+      dailyHours: facilityHours.operatingHours
     });
   }
   return null;
@@ -74,7 +75,7 @@ function getHoursInfo(
               dayOfWeek: facilityHours.dayOfWeek,
               status: facilityHours.status,
               statusText: facilityHours.statusText,
-              dailyHours: facilityHours.dailyHours,
+              dailyHours: facilityHours.dailyHours
             })
           );
         }
@@ -83,7 +84,7 @@ function getHoursInfo(
   }
   return FacilityHours.assign({
     id: facilityId,
-    hours: validDailyHours,
+    hours: validDailyHours
   });
 }
 
@@ -108,7 +109,7 @@ export class FacilityDB extends DB {
     facilityId?: string
   ): Promise<DBQuery<string, FacilityInfo>[]> {
     const { datastore } = this;
-    const query = datastore.createQuery("hours");
+    const query = datastore.createQuery('hours');
 
     try {
       const [hours] = await datastore.runQuery(query);
@@ -124,9 +125,9 @@ export class FacilityDB extends DB {
         throw new Error(`Invalid ID: ${id}`);
       } else {
         return Object.keys(ID_MAP)
-          .map((id) => getInfo(id, hours))
-          .filter((obj) => obj != null)
-          .map((info) => DB.query(info));
+          .map(id => getInfo(id, hours))
+          .filter(obj => obj != null)
+          .map(info => DB.query(info));
       }
     } catch (err) {
       console.log(err.message);
@@ -139,11 +140,11 @@ export class FacilityDB extends DB {
   ): /* eslint-disable-line class-methods-use-this */ Promise<
     DatabaseQueryNoParams<FacilityMetadata>[]
   > {
-    return Object.keys(facilityListType).map((key) =>
+    return Object.keys(facilityListType).map(key =>
       DB.query(
         FacilityMetadata.assign({
           displayName: facilityListType[key],
-          id: key,
+          id: key
         })
       )
     );
@@ -153,22 +154,22 @@ export class FacilityDB extends DB {
   async efacilityList(): /* eslint-disable-line class-methods-use-this */ Promise<
     DatabaseQueryNoParams<FacilityMetadata>[]
   > {
-    return Object.keys(DISPLAY_MAP).map((key) =>
+    return Object.keys(DISPLAY_MAP).map(key =>
       DB.query(
         FacilityMetadata.assign({
           displayName: DISPLAY_MAP[key],
-          id: key,
+          id: key
         })
       )
     );
   }
 
   async gymFacilityList(): Promise<DatabaseQueryNoParams<FacilityMetadata>[]> {
-    return Object.keys(GYM_DISPLAY_MAP).map((key) =>
+    return Object.keys(GYM_DISPLAY_MAP).map(key =>
       DB.query(
         FacilityMetadata.assign({
           displayName: DISPLAY_MAP[key],
-          id: key,
+          id: key
         })
       )
     );
@@ -180,7 +181,7 @@ export class FacilityDB extends DB {
     endDate?: string
   ): Promise<DBQuery<string, FacilityHours>[]> {
     const { datastore } = this;
-    const query = datastore.createQuery("development-testing-hours");
+    const query = datastore.createQuery('development-testing-hours');
     try {
       const [hoursrange] = await datastore.runQuery(query);
       if (facilityId) {
@@ -201,9 +202,9 @@ export class FacilityDB extends DB {
       } else {
         if (startDate && endDate) {
           return Object.keys(ID_MAP)
-            .map((id) => getHoursInfo(id, hoursrange, startDate, endDate))
-            .filter((obj) => obj != null)
-            .map((info) => DB.query(info));
+            .map(id => getHoursInfo(id, hoursrange, startDate, endDate))
+            .filter(obj => obj != null)
+            .map(info => DB.query(info));
         }
         throw new Error(`Missing start and/or end date`);
       }
@@ -216,11 +217,11 @@ export class FacilityDB extends DB {
   async gymFacilityHours(facilityId?: string, date?: string) {
     if (facilityId) {
       return (
-        await firebaseDB.collection("gymdata").doc(facilityId).get()
+        await firebaseDB.collection('gymdata').doc(facilityId).get()
       ).data();
     }
     const data = [];
-    const queryResult = await firebaseDB.collection("gymdata").get();
+    const queryResult = await firebaseDB.collection('gymdata').get();
     for (const doc of queryResult.docs) {
       const docData = doc.data();
       docData.id = doc.id;

--- a/src/v1/facilities/models/hours.ts
+++ b/src/v1/facilities/models/hours.ts
@@ -1,19 +1,24 @@
-import { JSONParsable, JSONObject, typedefs, JSONArray } from '../../lib/json';
-import { FacilityHourSet } from './info';
+import { JSONParsable, JSONObject, typedefs, JSONArray } from "../../lib/json";
+import { FacilityHourSet } from "./info";
 
-@JSONParsable({date: 'string', dayOfWeek: 'number', status: 'number', statusText: 'string' })
+@JSONParsable({
+  date: "string",
+  dayOfWeek: "number",
+  status: "number",
+  statusText: "string",
+})
 export class DailyHours extends JSONObject {
-  date: string; 
-  dayOfWeek: number; 
-  status: number; 
-  statusText: string; 
+  date: string;
+  dayOfWeek: number;
+  status: number;
+  statusText: string;
   @JSONArray(FacilityHourSet)
-  dailyHours: FacilityHourSet[]
+  dailyHours: FacilityHourSet;
 }
 
-@JSONParsable({id: 'string'})
+@JSONParsable({ id: "string" })
 export class FacilityHours extends JSONObject {
   id: string;
   @JSONArray(DailyHours)
-  hours: DailyHours[]; 
+  hours: DailyHours[];
 }

--- a/src/v1/facilities/models/info.ts
+++ b/src/v1/facilities/models/info.ts
@@ -1,9 +1,14 @@
-import { JSONParsable, JSONObject, JSONObjProperty, JSONEnum } from '../../lib/json';
-import { CampusLocation } from '../../models/campus';
+import {
+  JSONParsable,
+  JSONObject,
+  JSONObjProperty,
+  JSONEnum,
+} from "../../lib/json";
+import { CampusLocation } from "../../models/campus";
 
 @JSONParsable({
-  startTimestamp: 'number',
-  endTimestamp: 'number'
+  startTimestamp: "number",
+  endTimestamp: "number",
 })
 export class FacilityHourSet extends JSONObject {
   startTimestamp: number;
@@ -11,10 +16,10 @@ export class FacilityHourSet extends JSONObject {
 }
 
 @JSONParsable({
-  id: 'string',
-  nextOpen: 'number',
-  closingAt: 'number',
-  isOpen: 'boolean'
+  id: "string",
+  nextOpen: "number",
+  closingAt: "number",
+  isOpen: "boolean",
 })
 export class FacilityInfo extends JSONObject {
   id: string;

--- a/src/v1/history.ts
+++ b/src/v1/history.ts
@@ -44,20 +44,11 @@ const formattedHours = () => ({
 
 function format(analysis) {
   return analysis.map(({ id, history }) => {
-    const dailyHours = {};
-    Object.entries(history).forEach(([k, v]) => {
-      dailyHours[k] = Object.assign(formattedHours(), v);
-    });
-
     return {
       id,
-      hours: dailyHours,
+      hours: history,
     };
   });
-}
-
-function formatId(analysis, id) {
-  return analysis.find((v) => v.id === id);
 }
 
 function historicalData(id, mask) {
@@ -65,7 +56,7 @@ function historicalData(id, mask) {
     data = format(analysis);
   }
   if (id) {
-    const d = formatId(data, id);
+    const d = data.find((v) => v.id === id);
     if (d) {
       Object.entries(d.hours).forEach(([k, v]) => {
         d.hours[k] = Object.assign(v, mask[k]);
@@ -128,7 +119,6 @@ export default function routes(redis?: Redis, credentials?) {
 
         res.status(200).send(data);
       } catch (err) {
-        console.log(err);
         // TODO Send actual error codes based on errors. (this applies to all routes)
         res.status(400).send(err);
       }

--- a/src/v1/history.ts
+++ b/src/v1/history.ts
@@ -1,34 +1,43 @@
-import * as express from 'express';
-import { analysis } from './data/historicalAnalysis';
+import * as express from "express";
+import { Redis } from "ioredis";
+import { analysis } from "./data/historicalAnalysis";
+import { FacilityDB } from "./facilities/db";
+import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from "./mapping";
+import asyncify from "./lib/asyncify";
+import { cache } from "./lib/cache";
+import moment = require("moment");
+require("moment-timezone");
+
+moment.tz.setDefault("America/New_York");
 
 let data = null;
 
 function format(analysis) {
   const formattedHours = () => ({
-    '0': -1,
-    '1': -1,
-    '2': -1,
-    '3': -1,
-    '4': -1,
-    '5': -1,
-    '6': -1,
-    '7': -1,
-    '8': -1,
-    '9': -1,
-    '10': -1,
-    '11': -1,
-    '12': -1,
-    '13': -1,
-    '14': -1,
-    '15': -1,
-    '16': -1,
-    '17': -1,
-    '18': -1,
-    '19': -1,
-    '20': -1,
-    '21': -1,
-    '22': -1,
-    '23': -1
+    "0": -1,
+    "1": -1,
+    "2": -1,
+    "3": -1,
+    "4": -1,
+    "5": -1,
+    "6": -1,
+    "7": -1,
+    "8": -1,
+    "9": -1,
+    "10": -1,
+    "11": -1,
+    "12": -1,
+    "13": -1,
+    "14": -1,
+    "15": -1,
+    "16": -1,
+    "17": -1,
+    "18": -1,
+    "19": -1,
+    "20": -1,
+    "21": -1,
+    "22": -1,
+    "23": -1,
   });
 
   return analysis.map(({ id, history }) => {
@@ -39,29 +48,63 @@ function format(analysis) {
 
     return {
       id,
-      hours: dailyHours
+      hours: dailyHours,
     };
   });
 }
 
 function formatId(analysis, id) {
-  return analysis.find(v => v.id === id); 
+  return analysis.find((v) => v.id === id);
 }
 
-export default function handler(req: express.Request, res: express.Response): void {
+function historicalData(id, mask) {
   if (data == null) {
     data = format(analysis);
   }
-  if (req.query.id) {
-    const d = formatId(data, req.query.id); 
+  if (id) {
+    const d = formatId(data, id);
     if (d) {
-      res.status(200).send(JSON.stringify([d]));
-    }
-    else {
-      res.status(400).send('Invalid ID'); 
+      console.log(moment());
+      Object.entries(d.hours).forEach(([k, v]) => {
+        d.hours[k] = Object.assign(d.hours[k], mask);
+      });
+      return JSON.stringify([d]);
+    } else {
+      return "{}";
     }
   }
-  else {
-    res.status(200).send(JSON.stringify(data));
-  }
+}
+
+import Datastore = require("@google-cloud/datastore");
+
+export default function routes(redis?: Redis, credentials?) {
+  const datastore = new Datastore(credentials ? { credentials } : undefined);
+  const db = new FacilityDB(datastore);
+
+  const router = express.Router();
+
+  const historicalDataKey = (req) => `/historicalData?${req.query.id || ""}`;
+
+  router.get(
+    "/historicalData",
+    cache(historicalDataKey, redis),
+    asyncify(async (req: express.Request, res: express.Response) => {
+      try {
+        const mask = {};
+
+        const data = historicalData(req.query.id, mask);
+
+        if (redis) {
+          redis.setex(historicalDataKey(req), 60 * 10, data);
+        }
+
+        res.status(200).send(data);
+      } catch (err) {
+        // TODO Send actual error codes based on errors. (this applies to all routes)
+        res.status(400).send(err);
+      }
+    })
+  );
+
+  return router;
 }

--- a/src/v1/history.ts
+++ b/src/v1/history.ts
@@ -12,34 +12,37 @@ moment.tz.setDefault("America/New_York");
 
 let data = null;
 
-function format(analysis) {
-  const formattedHours = () => ({
-    "0": -1,
-    "1": -1,
-    "2": -1,
-    "3": -1,
-    "4": -1,
-    "5": -1,
-    "6": -1,
-    "7": -1,
-    "8": -1,
-    "9": -1,
-    "10": -1,
-    "11": -1,
-    "12": -1,
-    "13": -1,
-    "14": -1,
-    "15": -1,
-    "16": -1,
-    "17": -1,
-    "18": -1,
-    "19": -1,
-    "20": -1,
-    "21": -1,
-    "22": -1,
-    "23": -1,
-  });
+const range = (start, end, length = end - start + 1) =>
+  Array.from({ length }, (_, i) => start + i);
 
+const formattedHours = () => ({
+  "0": -1,
+  "1": -1,
+  "2": -1,
+  "3": -1,
+  "4": -1,
+  "5": -1,
+  "6": -1,
+  "7": -1,
+  "8": -1,
+  "9": -1,
+  "10": -1,
+  "11": -1,
+  "12": -1,
+  "13": -1,
+  "14": -1,
+  "15": -1,
+  "16": -1,
+  "17": -1,
+  "18": -1,
+  "19": -1,
+  "20": -1,
+  "21": -1,
+  "22": -1,
+  "23": -1,
+});
+
+function format(analysis) {
   return analysis.map(({ id, history }) => {
     const dailyHours = {};
     Object.entries(history).forEach(([k, v]) => {
@@ -64,15 +67,13 @@ function historicalData(id, mask) {
   if (id) {
     const d = formatId(data, id);
     if (d) {
-      console.log(moment());
       Object.entries(d.hours).forEach(([k, v]) => {
-        d.hours[k] = Object.assign(d.hours[k], mask);
+        d.hours[k] = Object.assign(v, mask[k]);
       });
       return JSON.stringify([d]);
-    } else {
-      return "{}";
     }
   }
+  throw new Error("Invalid ID");
 }
 
 import Datastore = require("@google-cloud/datastore");
@@ -90,7 +91,34 @@ export default function routes(redis?: Redis, credentials?) {
     cache(historicalDataKey, redis),
     asyncify(async (req: express.Request, res: express.Response) => {
       try {
-        const mask = {};
+        const facilityHours = await db.facilityHours(
+          req.query.id,
+          moment().format("YYYY-MM-DD"),
+          moment().add(7, "d").format("YYYY-MM-DD")
+        );
+        const results = facilityHours.map((v) => v.result)[0];
+
+        const mask = {
+          SUN: formattedHours(),
+          MON: formattedHours(),
+          TUE: formattedHours(),
+          WED: formattedHours(),
+          THU: formattedHours(),
+          FRI: formattedHours(),
+          SAT: formattedHours(),
+        };
+        results.hours.forEach((element) => {
+          const hours = element.dailyHours;
+          const start = moment.unix(hours.startTimestamp);
+          const end = moment.unix(hours.endTimestamp);
+          const day = start.format("ddd").toUpperCase();
+
+          const startHour = start.hour();
+          const endHour = end.hour();
+          for (const x of range(startHour, endHour)) {
+            delete mask[day][x];
+          }
+        });
 
         const data = historicalData(req.query.id, mask);
 
@@ -100,6 +128,7 @@ export default function routes(redis?: Redis, credentials?) {
 
         res.status(200).send(data);
       } catch (err) {
+        console.log(err);
         // TODO Send actual error codes based on errors. (this applies to all routes)
         res.status(400).send(err);
       }

--- a/src/v1/history.ts
+++ b/src/v1/history.ts
@@ -85,7 +85,7 @@ export default function routes(redis?: Redis, credentials?) {
         const facilityHours = await db.facilityHours(
           req.query.id,
           moment().format("YYYY-MM-DD"),
-          moment().add(7, "d").format("YYYY-MM-DD")
+          moment().add(6, "d").format("YYYY-MM-DD")
         );
         const results = facilityHours.map((v) => v.result)[0];
 

--- a/src/v1/history.ts
+++ b/src/v1/history.ts
@@ -2,9 +2,9 @@ import * as express from "express";
 import { Redis } from "ioredis";
 import { analysis } from "./data/historicalAnalysis";
 import { FacilityDB } from "./facilities/db";
-import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from "./mapping";
 import asyncify from "./lib/asyncify";
 import { cache } from "./lib/cache";
+
 import moment = require("moment");
 require("moment-timezone");
 

--- a/src/v1/server.ts
+++ b/src/v1/server.ts
@@ -1,21 +1,21 @@
-import * as express from 'express';
-import * as bodyParser from 'body-parser'
-import { Redis } from 'ioredis';
-import densityRoutes from './density/routes';
-import facilityRoutes from './facilities/routes';
-import diningRoutes from './dining/routes';
-import historicalRoute from './history';
-import Auth, { authenticated } from './auth';
+import * as express from "express";
+import * as bodyParser from "body-parser";
+import { Redis } from "ioredis";
+import densityRoutes from "./density/routes";
+import facilityRoutes from "./facilities/routes";
+import diningRoutes from "./dining/routes";
+import historicalRoutes from "./history";
+import Auth, { authenticated } from "./auth";
 
 export default function routes(redis?: Redis, credentials?) {
   const router = express.Router();
 
-  // router.use('/', authenticated);
-  router.use(bodyParser.json())
-  router.use('/', densityRoutes(redis, credentials));
-  router.use('/', facilityRoutes(redis, credentials));
-  router.use('/', diningRoutes(redis, credentials));
-  router.get('/historicalData', historicalRoute);
+  // router.use("/", authenticated);
+  router.use(bodyParser.json());
+  router.use("/", densityRoutes(redis, credentials));
+  router.use("/", facilityRoutes(redis, credentials));
+  router.use("/", diningRoutes(redis, credentials));
+  router.use("/", historicalRoutes(redis, credentials));
 
   return router;
 }

--- a/src/v1/server.ts
+++ b/src/v1/server.ts
@@ -10,7 +10,7 @@ import Auth, { authenticated } from "./auth";
 export default function routes(redis?: Redis, credentials?) {
   const router = express.Router();
 
-  // router.use("/", authenticated);
+  router.use("/", authenticated);
   router.use(bodyParser.json());
   router.use("/", densityRoutes(redis, credentials));
   router.use("/", facilityRoutes(redis, credentials));


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is a modification to some of the endpoints used by the Flux frontend.

- [x] factored out timezone with moment-timezone; used moment to generalize date format in `facilities/db.ts`
- [x] modified `history.ts` to use routes, modeling off the other endpoints
- [x] changed the `/historicalData` endpoint to only send data for open hours

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

The `/facilityHours` endpoint should now accept ISO date formats (`YYYY-MM-DD`).
![image](https://user-images.githubusercontent.com/34158284/85958013-47c03800-b960-11ea-922c-848ad56b121a.png)

The `/historicalData` endpoint should mask the closed hours, based on data for the upcoming week.
![image](https://user-images.githubusercontent.com/34158284/85958035-848c2f00-b960-11ea-8895-55b82e8953cc.png)


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

- The `/facilityHours` endpoint accepts any date format understood by moment. So, this change should not break any current code that uses `MM/DD/YY`.
- The `/historicalData` endpoint sends an error response if there is no valid facility `id` in the query string. This was a prior design choice.
- The open hours are based on the week immediately following the *date of the request*, not a manually inputted field.