### PR TITLE
Update gyms backend to granular data

### DIFF
--- a/src/v1/data/gymHistoricalAnalysis.ts
+++ b/src/v1/data/gymHistoricalAnalysis.ts
@@ -3,6 +3,43 @@ import { print } from 'util';
 import * as moment from 'moment';
 import { firebaseDB } from '../auth';
 
+const validDays = new Set([
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '0th',
+  '1st',
+  '2nd',
+  '3rd',
+  '4th',
+  '5th',
+  '6th',
+  'su',
+  'mo',
+  'tu',
+  'we',
+  'th',
+  'fr',
+  'sa',
+  'sun',
+  'mon',
+  'tue',
+  'wed',
+  'thu',
+  'fri',
+  'sat',
+  'sunday',
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday'
+]);
 
 // eslint-disable no-async-promise-executor
 
@@ -196,16 +233,21 @@ export const updateLiveAverages = async (gymID, day, data) => {
  * @param day day to fetch historical averages for
  */
 export const getHistoricalAverages = async (gymID, day) => {
-  if (!gymID && !day) throw new Error('Please enter a valid gym id and day.');
+  const validDay = validDays.has(day.toLowerCase());
+
+  if (!gymID && (!day || !validDay))
+    throw new Error('Please enter a valid gym id and day.');
   else if (!gymID) throw new Error('Please enter a valid gym id.');
-  else if (!day) throw new Error('Please enter a valid day.');
+  else if (!day || !validDay) throw new Error('Please enter a valid day.');
+
+  const dayFormat = moment().set({ day }).format('dddd');
 
   // get the live averages that are just calculated with the live data
   const doc = await firebaseDB
     .collection('gyms')
     .doc(gymID)
     .collection('history')
-    .doc(day)
+    .doc(dayFormat)
     .get();
 
   // get the spreadsheet averages stored in gymSpreadsheets
@@ -214,7 +256,7 @@ export const getHistoricalAverages = async (gymID, day) => {
     .collection('gymSpreadsheets')
     .doc(gymID)
     .collection('history')
-    .doc(day)
+    .doc(dayFormat)
     .get();
 
   // get the JSON contents of both the results.

--- a/src/v1/data/gymHistoricalAnalysis.ts
+++ b/src/v1/data/gymHistoricalAnalysis.ts
@@ -1,7 +1,8 @@
-import { database } from "firebase-admin";
-import { print } from "util";
-import { firebaseDB } from "../auth";
-const moment = require("moment");
+import { database } from 'firebase-admin';
+import { print } from 'util';
+import * as moment from 'moment';
+import { firebaseDB } from '../auth';
+
 
 // eslint-disable no-async-promise-executor
 
@@ -18,20 +19,20 @@ const moment = require("moment");
  * @param facility The facility id of the facility we are computing the historical
  * average of.
  */
-export const getAverageSpreadsheetHistoricalData = async (facility) => {
+export const getAverageSpreadsheetHistoricalData = async facility => {
   return new Promise((resolve, reject) => {
     const mappingAverage = {}; // {Monday: 11:20AM: {cardoSum: 300, weightSum: 400}}
 
     firebaseDB
-      .collection("gymHistory")
+      .collection('gymHistory')
       .doc(facility) // get facility
-      .collection("history") // go to the 'history' collection of that facility
+      .collection('history') // go to the 'history' collection of that facility
       .get() // get all documents
-      .then((querySnapshot) => {
-        querySnapshot.docs.forEach((doc) => {
+      .then(querySnapshot => {
+        querySnapshot.docs.forEach(doc => {
           const docDataContents = doc.data().data; // This contains the mapping from time to occupancies
           const dayForData = doc.data().day;
-          Object.keys(docDataContents).forEach((time) => {
+          Object.keys(docDataContents).forEach(time => {
             // The keys of the JSON are the times for a specific day
             const occupancy = docDataContents[time];
             if (!(dayForData in mappingAverage)) {
@@ -42,7 +43,7 @@ export const getAverageSpreadsheetHistoricalData = async (facility) => {
                 cardioAverage: occupancy.cardio === -1 ? 0 : occupancy.cardio,
                 weightAverage: occupancy.weights === -1 ? 0 : occupancy.weights,
                 cardioCount: 1,
-                weightCount: 1,
+                weightCount: 1
               };
             } else if (!(time in mappingAverage[dayForData])) {
               // Check if a specific time has been added to the mappings.å
@@ -50,7 +51,7 @@ export const getAverageSpreadsheetHistoricalData = async (facility) => {
                 cardioAverage: occupancy.cardio === -1 ? 0 : occupancy.cardio,
                 weightAverage: occupancy.weights === -1 ? 0 : occupancy.weights,
                 cardioCount: 1,
-                weightCount: 1,
+                weightCount: 1
               };
               // mappingCount[dayForData][time] = { cardioCount: 1, weightCount: 1 }
             } else {
@@ -76,7 +77,7 @@ export const getAverageSpreadsheetHistoricalData = async (facility) => {
         });
         resolve(mappingAverage);
       })
-      .catch((err) => reject(err));
+      .catch(err => reject(err));
   });
 };
 
@@ -89,23 +90,23 @@ export const getAverageSpreadsheetHistoricalData = async (facility) => {
  */
 export const updateSpreadsheetAverages = () => {
   return new Promise((resolve, reject) => {
-    getAverageSpreadsheetHistoricalData("noyes")
-      .then(async (results) => {
+    getAverageSpreadsheetHistoricalData('noyes')
+      .then(async results => {
         const averageDocuments = await firebaseDB
-          .collection("gyms")
-          .doc("noyes")
-          .collection("history");
+          .collection('gyms')
+          .doc('noyes')
+          .collection('history');
 
-        Object.keys(results).forEach((day) => {
+        Object.keys(results).forEach(day => {
           averageDocuments
             .doc(day)
             .set(results[day])
-            .catch((err) => reject(err));
+            .catch(err => reject(err));
         });
 
         resolve();
       })
-      .catch((err) => reject(err));
+      .catch(err => reject(err));
   });
 };
 
@@ -132,15 +133,15 @@ export const updateSpreadsheetAverages = () => {
 export const updateLiveAverages = async (gymID, day, data) => {
   // get the live averages that are just calculated with the live data
   const doc = await firebaseDB
-    .collection("gyms")
+    .collection('gyms')
     .doc(gymID)
-    .collection("history")
+    .collection('history')
     .doc(day)
     .get();
 
   // get the JSON contents of both the results.
   const docData = doc.data();
-  if (!docData) throw new Error("Could not fetch live averages");
+  if (!docData) throw new Error('Could not fetch live averages');
 
   // check if there is a time doc for this time
   if (docData[data.time]) {
@@ -178,12 +179,12 @@ export const updateLiveAverages = async (gymID, day, data) => {
   // push everything back to firebase.
   // eslint-disable-next-line no-async-promise-executor
   await firebaseDB
-    .collection("gyms")
+    .collection('gyms')
     .doc(gymID)
-    .collection("history")
+    .collection('history')
     .doc(day)
     .set(docData)
-    .catch((err) => {
+    .catch(err => {
       throw new Error(err);
     });
 };
@@ -195,36 +196,36 @@ export const updateLiveAverages = async (gymID, day, data) => {
  * @param day day to fetch historical averages for
  */
 export const getHistoricalAverages = async (gymID, day) => {
-  if (!gymID && !day) throw new Error("Please enter a valid gym id and day.");
-  else if (!gymID) throw new Error("Please enter a valid gym id.");
-  else if (!day) throw new Error("Please enter a valid day.");
+  if (!gymID && !day) throw new Error('Please enter a valid gym id and day.');
+  else if (!gymID) throw new Error('Please enter a valid gym id.');
+  else if (!day) throw new Error('Please enter a valid day.');
 
   // get the live averages that are just calculated with the live data
   const doc = await firebaseDB
-    .collection("gyms")
+    .collection('gyms')
     .doc(gymID)
-    .collection("history")
+    .collection('history')
     .doc(day)
     .get();
 
   // get the spreadsheet averages stored in gymSpreadsheets
   // eslint-disable-next-line no-async-promise-executor
   const spreadsheetDoc = await firebaseDB
-    .collection("gymSpreadsheets")
+    .collection('gymSpreadsheets')
     .doc(gymID)
-    .collection("history")
+    .collection('history')
     .doc(day)
     .get();
 
   // get the JSON contents of both the results.
   const docData = doc.data();
-  if (!docData) throw new Error("Could not fetch live averages.");
+  if (!docData) throw new Error('Could not fetch live averages.');
 
   const spreadsheetData = spreadsheetDoc.data();
-  if (!spreadsheetData) throw new Error("Could not fetch spreadsheet averages");
+  if (!spreadsheetData) throw new Error('Could not fetch spreadsheet averages');
 
   const res = [];
-  Object.keys(spreadsheetData).forEach((time) => {
+  Object.keys(spreadsheetData).forEach(time => {
     // retrieve cardio/weight data from the live averages JSON, and deal
     // with the case where there is no data for this time by setting it to 0
     const cardioLiveAverage = (docData[time] || 0).cardioLiveAverage || 0;
@@ -248,16 +249,16 @@ export const getHistoricalAverages = async (gymID, day) => {
     const data = {
       time,
       cardioAverage: newAggregateCardioAvg,
-      weightAverage: newAggregateWeightAvg,
+      weightAverage: newAggregateWeightAvg
     };
 
     res.push(data);
   });
 
   res.sort((a, b) => {
-    const date = moment().format("YYYY-MM-DD ");
-    const timeA = moment(date + a.time, "YYYY-MM-DD h:mma");
-    const timeB = moment(date + b.time, "YYYY-MM-DD h:mma");
+    const date = moment().format('YYYY-MM-DD ');
+    const timeA = moment(date + a.time, 'YYYY-MM-DD h:mma');
+    const timeB = moment(date + b.time, 'YYYY-MM-DD h:mma');
     return timeA.diff(timeB);
   });
   return res;

--- a/src/v1/data/gymHistoricalAnalysis.ts
+++ b/src/v1/data/gymHistoricalAnalysis.ts
@@ -1,185 +1,192 @@
-import { database } from 'firebase-admin'
-import { print } from 'util'
-import { firebaseDB } from '../auth'
+import { database } from "firebase-admin";
+import { print } from "util";
+import { firebaseDB } from "../auth";
+const moment = require("moment");
 
 // eslint-disable no-async-promise-executor
 
 /**
  * This function computes the historical average of the weight and cardio occupancies
- * by computing the mean of the respective values for every day on every time slot. 
+ * by computing the mean of the respective values for every day on every time slot.
  * For example, the output of this function will store the averages as { Monday: {11:15AM: {cardioAverage: 13, weightAverage: 12.5},
  *                                                                                {12:30PM: {cardioAverage: 15, weightAverage: 20}}}}
- * The counts of the entries for cardio and weight on each day for each time are recorded in a similar format. 
- * 
+ * The counts of the entries for cardio and weight on each day for each time are recorded in a similar format.
+ *
  * This function also goes through the entire collection of history documents, and should only be used
- * when the all the historical averages need to be computed from scratch.  
- * 
+ * when the all the historical averages need to be computed from scratch.
+ *
  * @param facility The facility id of the facility we are computing the historical
  * average of.
  */
-export const getAverageSpreadsheetHistoricalData = async facility => {
+export const getAverageSpreadsheetHistoricalData = async (facility) => {
   return new Promise((resolve, reject) => {
-    const mappingAverage = {} // {Monday: 11:20AM: {cardoSum: 300, weightSum: 400}}
+    const mappingAverage = {}; // {Monday: 11:20AM: {cardoSum: 300, weightSum: 400}}
 
-    firebaseDB.collection('gymHistory')
+    firebaseDB
+      .collection("gymHistory")
       .doc(facility) // get facility
-      .collection('history') // go to the 'history' collection of that facility
+      .collection("history") // go to the 'history' collection of that facility
       .get() // get all documents
-      .then(querySnapshot => {
-        querySnapshot.docs.forEach(doc => {
-          const docDataContents = doc.data().data // This contains the mapping from time to occupancies
-          const dayForData = doc.data().day
-          Object.keys(docDataContents).forEach(time => { // The keys of the JSON are the times for a specific day
-            const occupancy = docDataContents[time]
-            if (!(dayForData in mappingAverage)) { // Create the appropriate mapping for the day if it doesn't exist
-              // Throughout this function, whenever we encounter a -1 (implying there's no one there), we simply substitute with a 0. 
-              mappingAverage[dayForData] = {}
+      .then((querySnapshot) => {
+        querySnapshot.docs.forEach((doc) => {
+          const docDataContents = doc.data().data; // This contains the mapping from time to occupancies
+          const dayForData = doc.data().day;
+          Object.keys(docDataContents).forEach((time) => {
+            // The keys of the JSON are the times for a specific day
+            const occupancy = docDataContents[time];
+            if (!(dayForData in mappingAverage)) {
+              // Create the appropriate mapping for the day if it doesn't exist
+              // Throughout this function, whenever we encounter a -1 (implying there's no one there), we simply substitute with a 0.
+              mappingAverage[dayForData] = {};
               mappingAverage[dayForData][time] = {
-                cardioAverage:
-                  (occupancy.cardio === -1 ? 0 : occupancy.cardio),
-                weightAverage:
-                  (occupancy.weights === -1 ? 0 : occupancy.weights),
+                cardioAverage: occupancy.cardio === -1 ? 0 : occupancy.cardio,
+                weightAverage: occupancy.weights === -1 ? 0 : occupancy.weights,
                 cardioCount: 1,
-                weightCount: 1
-              }
-
-            } else if (!(time in mappingAverage[dayForData])) { // Check if a specific time has been added to the mappings.å
+                weightCount: 1,
+              };
+            } else if (!(time in mappingAverage[dayForData])) {
+              // Check if a specific time has been added to the mappings.å
               mappingAverage[dayForData][time] = {
-                cardioAverage:
-                  (occupancy.cardio === -1 ? 0 : occupancy.cardio),
-                weightAverage:
-                  (occupancy.weights === -1 ? 0 : occupancy.weights),
+                cardioAverage: occupancy.cardio === -1 ? 0 : occupancy.cardio,
+                weightAverage: occupancy.weights === -1 ? 0 : occupancy.weights,
                 cardioCount: 1,
-                weightCount: 1
-              }
+                weightCount: 1,
+              };
               // mappingCount[dayForData][time] = { cardioCount: 1, weightCount: 1 }
             } else {
               // The current day and time already exist, adjust values in mappings.
               // Compute the new average based on the current acccumulation by (newVal + oldAverage * oldCount)/(oldCount + 1
               mappingAverage[dayForData][time].cardioAverage =
-                ((occupancy.cardio === -1 ? 0 : occupancy.cardio)
-                  + mappingAverage[dayForData][time].cardioAverage
-                  * mappingAverage[dayForData][time].cardioCount)
-                / (mappingAverage[dayForData][time].cardioCount + 1)
-
+                ((occupancy.cardio === -1 ? 0 : occupancy.cardio) +
+                  mappingAverage[dayForData][time].cardioAverage *
+                    mappingAverage[dayForData][time].cardioCount) /
+                (mappingAverage[dayForData][time].cardioCount + 1);
 
               mappingAverage[dayForData][time].weightAverage =
-                ((occupancy.cardio === -1 ? 0 : occupancy.weights)
-                  + mappingAverage[dayForData][time].weightAverage
-                  * mappingAverage[dayForData][time].weightCount)
-                / (mappingAverage[dayForData][time].weightCount + 1)
+                ((occupancy.cardio === -1 ? 0 : occupancy.weights) +
+                  mappingAverage[dayForData][time].weightAverage *
+                    mappingAverage[dayForData][time].weightCount) /
+                (mappingAverage[dayForData][time].weightCount + 1);
 
-              // Update mapping counts. 
-              mappingAverage[dayForData][time].cardioCount += 1
-              mappingAverage[dayForData][time].weightCount += 1
+              // Update mapping counts.
+              mappingAverage[dayForData][time].cardioCount += 1;
+              mappingAverage[dayForData][time].weightCount += 1;
             }
-          })
-        })
-        resolve(mappingAverage)
+          });
+        });
+        resolve(mappingAverage);
       })
-      .catch(err => reject(err))
-  })
-}
+      .catch((err) => reject(err));
+  });
+};
 
 /**
  * This method aggregates the spreadsheet averages in the Firebase collection
- * gyms |> gym_name |> history. 
- * 
- * NOTE: This method is just kept until Changyuan's script can completely handle 
- * spreadsheet stuff. Don't use this. 
+ * gyms |> gym_name |> history.
+ *
+ * NOTE: This method is just kept until Changyuan's script can completely handle
+ * spreadsheet stuff. Don't use this.
  */
 export const updateSpreadsheetAverages = () => {
   return new Promise((resolve, reject) => {
-    getAverageSpreadsheetHistoricalData('noyes')
-      .then(async results => {
+    getAverageSpreadsheetHistoricalData("noyes")
+      .then(async (results) => {
         const averageDocuments = await firebaseDB
-          .collection('gyms')
-          .doc('noyes')
-          .collection('history')
+          .collection("gyms")
+          .doc("noyes")
+          .collection("history");
 
-        Object.keys(results).forEach(day => {
-          averageDocuments.doc(day).set(results[day]).catch(err => reject(err))
-        })
+        Object.keys(results).forEach((day) => {
+          averageDocuments
+            .doc(day)
+            .set(results[day])
+            .catch((err) => reject(err));
+        });
 
-        resolve()
+        resolve();
       })
-      .catch(err => reject(err))
-  })
-}
+      .catch((err) => reject(err));
+  });
+};
 
 /**
  * This function will update the live averages for the Firebase document corresponding
- * to the path `gyms/[gymID]/history/[day]`. It will create a new field for the 
+ * to the path `gyms/[gymID]/history/[day]`. It will create a new field for the
  * this document's data path if `[data.time]` isn't already a field (which means
  * the time for which we're updating the live averages doesn't exist on the database,
  * and we need to create a new field for this time). If the time already exists as
- * a field for this document, then the existing averages are updated using `[data.weights]` 
+ * a field for this document, then the existing averages are updated using `[data.weights]`
  * and `[data.cardio]`.
- * 
+ *
  * @param gymID A valid gym facility identifier, as used on Firebase.
- * 
- * @param day The string representation of the day (Monday, Tuesday, etc. ) the average is being 
+ *
+ * @param day The string representation of the day (Monday, Tuesday, etc. ) the average is being
  * updated for
- * 
+ *
  * @param data An Object containing information about the time, and the new cardio and weight
- * data. 
+ * data.
  * @requires data.time is a string representation of 12-hour regular time, rounded to the nearest
  * quarter. Examples: 1:15pm, 11:45am, 12:15pm
  *
  */
 export const updateLiveAverages = async (gymID, day, data) => {
-
   // get the live averages that are just calculated with the live data
-  const doc = await firebaseDB.collection('gyms')
+  const doc = await firebaseDB
+    .collection("gyms")
     .doc(gymID)
-    .collection('history')
+    .collection("history")
     .doc(day)
-    .get()
+    .get();
 
   // get the JSON contents of both the results.
-  const docData = doc.data()
-  if (!docData) throw new Error('Could not fetch live averages')
+  const docData = doc.data();
+  if (!docData) throw new Error("Could not fetch live averages");
 
   // check if there is a time doc for this time
   if (docData[data.time]) {
-
     // compute the running live average. Technically we don't need to compute the live average?
     const newLiveCardioAvg =
-      (data.cardio + docData[data.time].cardioLiveAverage * docData[data.time].cardioLiveCount)
-      / (docData[data.time].cardioLiveCount + 1)
+      (data.cardio +
+        docData[data.time].cardioLiveAverage *
+          docData[data.time].cardioLiveCount) /
+      (docData[data.time].cardioLiveCount + 1);
 
     // compute new live count
-    const newLiveCardioCount = docData[data.time].cardioLiveCount + 1
+    const newLiveCardioCount = docData[data.time].cardioLiveCount + 1;
 
     // compute new live averages (this average doesn't include the spreadsheet averages!)
     const newLiveWeightAvg =
-      (data.weights + docData[data.time].weightLiveAverage * docData[data.time].weightLiveCount)
-      / (docData[data.time].weightLiveCount + 1)
+      (data.weights +
+        docData[data.time].weightLiveAverage *
+          docData[data.time].weightLiveCount) /
+      (docData[data.time].weightLiveCount + 1);
 
-    const newLiveWeightCount = docData[data.time].weightLiveCount + 1
+    const newLiveWeightCount = docData[data.time].weightLiveCount + 1;
 
-    docData[data.time].cardioLiveAverage = newLiveCardioAvg
-    docData[data.time].cardioLiveCount = newLiveCardioCount
-    docData[data.time].weightLiveAverage = newLiveWeightAvg
-    docData[data.time].weightLiveCount = newLiveWeightCount
+    docData[data.time].cardioLiveAverage = newLiveCardioAvg;
+    docData[data.time].cardioLiveCount = newLiveCardioCount;
+    docData[data.time].weightLiveAverage = newLiveWeightAvg;
+    docData[data.time].weightLiveCount = newLiveWeightCount;
   } else {
-    docData[data.time] = {}
-    docData[data.time].cardioLiveAverage = data.cardio
-    docData[data.time].cardioLiveCount = 1
-    docData[data.time].weightLiveAverage = data.weights
-    docData[data.time].weightLiveCount = 1
+    docData[data.time] = {};
+    docData[data.time].cardioLiveAverage = data.cardio;
+    docData[data.time].cardioLiveCount = 1;
+    docData[data.time].weightLiveAverage = data.weights;
+    docData[data.time].weightLiveCount = 1;
   }
 
   // push everything back to firebase.
   // eslint-disable-next-line no-async-promise-executor
   await firebaseDB
-    .collection('gyms')
+    .collection("gyms")
     .doc(gymID)
-    .collection('history')
+    .collection("history")
     .doc(day)
     .set(docData)
-    .catch(err => { throw new Error(err) })
-}
+    .catch((err) => {
+      throw new Error(err);
+    });
+};
 
 /**
  * This function gets the historical averages of a specified gym on a specified day. This historical average
@@ -188,57 +195,70 @@ export const updateLiveAverages = async (gymID, day, data) => {
  * @param day day to fetch historical averages for
  */
 export const getHistoricalAverages = async (gymID, day) => {
+  if (!gymID && !day) throw new Error("Please enter a valid gym id and day.");
+  else if (!gymID) throw new Error("Please enter a valid gym id.");
+  else if (!day) throw new Error("Please enter a valid day.");
+
   // get the live averages that are just calculated with the live data
-  const doc = await firebaseDB.collection('gyms')
+  const doc = await firebaseDB
+    .collection("gyms")
     .doc(gymID)
-    .collection('history')
+    .collection("history")
     .doc(day)
-    .get()
+    .get();
 
   // get the spreadsheet averages stored in gymSpreadsheets
   // eslint-disable-next-line no-async-promise-executor
-  const spreadsheetDoc = await firebaseDB.collection('gymSpreadsheets')
+  const spreadsheetDoc = await firebaseDB
+    .collection("gymSpreadsheets")
     .doc(gymID)
-    .collection('history')
+    .collection("history")
     .doc(day)
-    .get()
+    .get();
 
   // get the JSON contents of both the results.
-  const docData = doc.data()
-  if (!docData) throw new Error('Could not fetch live averages')
+  const docData = doc.data();
+  if (!docData) throw new Error("Could not fetch live averages.");
 
-  const spreadsheetData = spreadsheetDoc.data()
-  if (!spreadsheetData) throw new Error('Could not fetch spreadsheet averages')
+  const spreadsheetData = spreadsheetDoc.data();
+  if (!spreadsheetData) throw new Error("Could not fetch spreadsheet averages");
 
-  const res = []
-  Object.keys(spreadsheetData).forEach(time => {
-
+  const res = [];
+  Object.keys(spreadsheetData).forEach((time) => {
     // retrieve cardio/weight data from the live averages JSON, and deal
     // with the case where there is no data for this time by setting it to 0
-    const cardioLiveAverage = (docData[time] || 0).cardioLiveAverage || 0
-    const cardioLiveCount = (docData[time] || 0).cardioLiveCount || 0
-    const weightLiveAverage = (docData[time] || 0).weightLiveAverage || 0
-    const weightLiveCount = (docData[time] || 0).weightLiveCount || 0
+    const cardioLiveAverage = (docData[time] || 0).cardioLiveAverage || 0;
+    const cardioLiveCount = (docData[time] || 0).cardioLiveCount || 0;
+    const weightLiveAverage = (docData[time] || 0).weightLiveAverage || 0;
+    const weightLiveCount = (docData[time] || 0).weightLiveCount || 0;
 
     // compute new aggregate averages by averaging the live and spreadsheet averages
     const newAggregateCardioAvg =
       (cardioLiveAverage * cardioLiveCount +
-        spreadsheetData[time].cardioAverage * spreadsheetData[time].cardioCount)
-      / (cardioLiveCount + spreadsheetData[time].cardioCount)
+        spreadsheetData[time].cardioAverage *
+          spreadsheetData[time].cardioCount) /
+      (cardioLiveCount + spreadsheetData[time].cardioCount);
 
     const newAggregateWeightAvg =
       (weightLiveAverage * weightLiveCount +
-        spreadsheetData[time].weightsAverage * spreadsheetData[time].weightsCount)
-      / (weightLiveCount + spreadsheetData[time].weightsCount)
+        spreadsheetData[time].weightsAverage *
+          spreadsheetData[time].weightsCount) /
+      (weightLiveCount + spreadsheetData[time].weightsCount);
 
     const data = {
       time,
       cardioAverage: newAggregateCardioAvg,
-      weightAverage: newAggregateWeightAvg
-    }
+      weightAverage: newAggregateWeightAvg,
+    };
 
-    res.push(data)
-  })
+    res.push(data);
+  });
 
-  return res
-}
+  res.sort((a, b) => {
+    const date = moment().format("YYYY-MM-DD ");
+    const timeA = moment(date + a.time, "YYYY-MM-DD h:mma");
+    const timeB = moment(date + b.time, "YYYY-MM-DD h:mma");
+    return timeA.diff(timeB);
+  });
+  return res;
+};

--- a/src/v1/density/db.ts
+++ b/src/v1/density/db.ts
@@ -1,92 +1,111 @@
-import { print } from 'util';
-import { ID_MAP, UNITNAME_MAP, GYM_DISPLAY_MAP } from '../mapping';
-import { DBQuery, DB } from '../db';
-import * as Util from '../util';
-import { DensityDocument } from './models/density';
-import { firebaseDB } from '../auth';
+import { print } from "util";
+import { ID_MAP, UNITNAME_MAP, GYM_DISPLAY_MAP } from "../mapping";
+import { DBQuery, DB } from "../db";
+import * as Util from "../util";
+import { DensityDocument } from "./models/density";
+import { firebaseDB } from "../auth";
 
 const DAYS = {
-    'Monday': 'M',
-    'Tuesday': 'T',
-    'Wednesday': 'W',
-    'Thursday': 'R',
-    'Friday': 'F',
-    'Saturday': 'S',
-    'Sunday': 'Su'
-}
+  Monday: "M",
+  Tuesday: "T",
+  Wednesday: "W",
+  Thursday: "R",
+  Friday: "F",
+  Saturday: "S",
+  Sunday: "Su",
+};
 
 export class DensityDB extends DB {
-    /* eslint-disable no-useless-constructor */
-    public constructor(datastore) {
-        super(datastore);
-    }
-    /* eslint-enable */
+  /* eslint-disable no-useless-constructor */
+  public constructor(datastore) {
+    super(datastore);
+  }
+  /* eslint-enable */
 
-    async howDense(facilityId?: string): Promise<DBQuery<string, DensityDocument>[]> {
-        const {
-            datastore
-        } = this;
-        const query = datastore.createQuery('density', 'density_info');
-        const [entities] = await datastore.runQuery(query);
-        if (facilityId) {
-            const id = facilityId;
-            const entity = entities.find(e => e.id === Util.strip(ID_MAP[id]));
-            if (entity && id in ID_MAP) {
-                return [
-                    DB.query(
-                        DensityDocument.fromJSON({
-                            id,
-                            density: entity.density
-                        })
-                    )
-                ];
-            }
-            throw new Error('Invalid ID');
-        } else {
-            return entities.map(e => {
-                return DB.query(
-                    DensityDocument.fromJSON({
-                        id: UNITNAME_MAP[e.id],
-                        density: e.density
-                    })
-                );
+  async howDense(
+    facilityId?: string
+  ): Promise<DBQuery<string, DensityDocument>[]> {
+    const { datastore } = this;
+    const query = datastore.createQuery("density", "density_info");
+    const [entities] = await datastore.runQuery(query);
+    if (facilityId) {
+      const id = facilityId;
+      const entity = entities.find((e) => e.id === Util.strip(ID_MAP[id]));
+      if (entity && id in ID_MAP) {
+        return [
+          DB.query(
+            DensityDocument.fromJSON({
+              id,
+              density: entity.density,
+            })
+          ),
+        ];
+      }
+      throw new Error("Invalid ID");
+    } else {
+      return entities.map((e) => {
+        return DB.query(
+          DensityDocument.fromJSON({
+            id: UNITNAME_MAP[e.id],
+            density: e.density,
+          })
+        );
+      });
+    }
+  }
+
+  async getAllGymsJSONArray() {
+    const jsonArr = [];
+    await firebaseDB
+      .collection("gyms")
+      .get()
+      .then(async (gymsSnapshot) => {
+        for (const doc of gymsSnapshot.docs) {
+          const facId = doc.id;
+          const gymCountCollection = firebaseDB
+            .collection("gyms")
+            .doc(facId)
+            .collection("counts");
+          // eslint-disable-next-line no-await-in-loop
+          await gymCountCollection
+            .orderBy("time", "desc")
+            .limit(1)
+            .get()
+            .then((gymCountSnapshot) => {
+              const facilityObj: any = {};
+              facilityObj.cardio = gymCountSnapshot.docs[0].get("cardio");
+              facilityObj.weights = gymCountSnapshot.docs[0].get("weights");
+              facilityObj.id = facId;
+              jsonArr.push(facilityObj);
             });
         }
-    }
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+    return jsonArr;
+  }
 
-    async getAllGymsJSONArray() {
-        const jsonArr = []
-        await firebaseDB.collection('gymdata').get().then(async gymsSnapshot => {
-            for (const doc of gymsSnapshot.docs) {
-                const facId = doc.id
-                const gymCountCollection = firebaseDB.collection('gymdata').doc(facId).collection('counts')
-                // eslint-disable-next-line no-await-in-loop
-                await gymCountCollection.orderBy('time', 'desc').limit(1).get().then(gymCountSnapshot => {
-                    const facilityObj: any = {}
-                    facilityObj.cardio = gymCountSnapshot.docs[0].get('cardio')
-                    facilityObj.weights = gymCountSnapshot.docs[0].get('weights')
-                    facilityObj.id = facId
-                    jsonArr.push(facilityObj)
-                })
-            }
-        }).catch(err => {
-            console.log(err)
+  async gymHowDense(facilityId?: string) {
+    const json: any = {};
+    if (facilityId) {
+      const gymCountCollection = firebaseDB
+        .collection("gyms")
+        .doc(facilityId)
+        .collection("counts");
+      await gymCountCollection
+        .orderBy("time", "desc")
+        .limit(1)
+        .get()
+        .then((snapshot) => {
+          json.cardio = snapshot.docs[0].get("cardio");
+          json.weights = snapshot.docs[0].get("weights");
         })
-        return jsonArr
+        .catch((err) => {
+          console.log(err);
+        });
+      return json;
     }
-
-    async gymHowDense(facilityId?: string) {
-        const json: any = {}
-        if (facilityId) {
-            const gymCountCollection = firebaseDB.collection('gymdata').doc(facilityId).collection('counts')
-            await gymCountCollection.orderBy('time', 'desc').limit(1).get().then(snapshot => {
-                json.cardio = snapshot.docs[0].get('cardio')
-                json.weights = snapshot.docs[0].get('weights')
-            }).catch(err => {
-                console.log(err)
-            })
-            return json
-        }
-        return this.getAllGymsJSONArray()
-    }
+    return this.getAllGymsJSONArray();
+  }
 }

--- a/src/v1/density/db.ts
+++ b/src/v1/density/db.ts
@@ -1,18 +1,18 @@
-import { print } from "util";
-import { ID_MAP, UNITNAME_MAP, GYM_DISPLAY_MAP } from "../mapping";
-import { DBQuery, DB } from "../db";
-import * as Util from "../util";
-import { DensityDocument } from "./models/density";
-import { firebaseDB } from "../auth";
+import { print } from 'util';
+import { ID_MAP, UNITNAME_MAP, GYM_DISPLAY_MAP } from '../mapping';
+import { DBQuery, DB } from '../db';
+import * as Util from '../util';
+import { DensityDocument } from './models/density';
+import { firebaseDB } from '../auth';
 
 const DAYS = {
-  Monday: "M",
-  Tuesday: "T",
-  Wednesday: "W",
-  Thursday: "R",
-  Friday: "F",
-  Saturday: "S",
-  Sunday: "Su",
+  Monday: 'M',
+  Tuesday: 'T',
+  Wednesday: 'W',
+  Thursday: 'R',
+  Friday: 'F',
+  Saturday: 'S',
+  Sunday: 'Su'
 };
 
 export class DensityDB extends DB {
@@ -26,28 +26,28 @@ export class DensityDB extends DB {
     facilityId?: string
   ): Promise<DBQuery<string, DensityDocument>[]> {
     const { datastore } = this;
-    const query = datastore.createQuery("density", "density_info");
+    const query = datastore.createQuery('density', 'density_info');
     const [entities] = await datastore.runQuery(query);
     if (facilityId) {
       const id = facilityId;
-      const entity = entities.find((e) => e.id === Util.strip(ID_MAP[id]));
+      const entity = entities.find(e => e.id === Util.strip(ID_MAP[id]));
       if (entity && id in ID_MAP) {
         return [
           DB.query(
             DensityDocument.fromJSON({
               id,
-              density: entity.density,
+              density: entity.density
             })
-          ),
+          )
         ];
       }
-      throw new Error("Invalid ID");
+      throw new Error('Invalid ID');
     } else {
-      return entities.map((e) => {
+      return entities.map(e => {
         return DB.query(
           DensityDocument.fromJSON({
             id: UNITNAME_MAP[e.id],
-            density: e.density,
+            density: e.density
           })
         );
       });
@@ -57,30 +57,30 @@ export class DensityDB extends DB {
   async getAllGymsJSONArray() {
     const jsonArr = [];
     await firebaseDB
-      .collection("gyms")
+      .collection('gyms')
       .get()
-      .then(async (gymsSnapshot) => {
+      .then(async gymsSnapshot => {
         for (const doc of gymsSnapshot.docs) {
           const facId = doc.id;
           const gymCountCollection = firebaseDB
-            .collection("gyms")
+            .collection('gyms')
             .doc(facId)
-            .collection("counts");
+            .collection('counts');
           // eslint-disable-next-line no-await-in-loop
           await gymCountCollection
-            .orderBy("time", "desc")
+            .orderBy('time', 'desc')
             .limit(1)
             .get()
-            .then((gymCountSnapshot) => {
+            .then(gymCountSnapshot => {
               const facilityObj: any = {};
-              facilityObj.cardio = gymCountSnapshot.docs[0].get("cardio");
-              facilityObj.weights = gymCountSnapshot.docs[0].get("weights");
+              facilityObj.cardio = gymCountSnapshot.docs[0].get('cardio');
+              facilityObj.weights = gymCountSnapshot.docs[0].get('weights');
               facilityObj.id = facId;
               jsonArr.push(facilityObj);
             });
         }
       })
-      .catch((err) => {
+      .catch(err => {
         console.log(err);
       });
     return jsonArr;
@@ -90,18 +90,18 @@ export class DensityDB extends DB {
     const json: any = {};
     if (facilityId) {
       const gymCountCollection = firebaseDB
-        .collection("gyms")
+        .collection('gyms')
         .doc(facilityId)
-        .collection("counts");
+        .collection('counts');
       await gymCountCollection
-        .orderBy("time", "desc")
+        .orderBy('time', 'desc')
         .limit(1)
         .get()
-        .then((snapshot) => {
-          json.cardio = snapshot.docs[0].get("cardio");
-          json.weights = snapshot.docs[0].get("weights");
+        .then(snapshot => {
+          json.cardio = snapshot.docs[0].get('cardio');
+          json.weights = snapshot.docs[0].get('weights');
         })
-        .catch((err) => {
+        .catch(err => {
           console.log(err);
         });
       return json;

--- a/src/v1/density/routes.ts
+++ b/src/v1/density/routes.ts
@@ -15,20 +15,20 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import * as express from "express";
-import { Redis } from "ioredis";
-import asyncify from "../lib/asyncify";
-import { DensityDB } from "./db";
-import { cache } from "../lib/cache";
+import * as express from 'express';
+import { Redis } from 'ioredis';
+import * as moment from 'moment';
+import asyncify from '../lib/asyncify';
+import { DensityDB } from './db';
+import { cache } from '../lib/cache';
 import {
   getAverageSpreadsheetHistoricalData,
   updateLiveAverages,
-  getHistoricalAverages,
-} from "../data/gymHistoricalAnalysis";
-const moment = require("moment");
+  getHistoricalAverages
+} from '../data/gymHistoricalAnalysis';
 
-import Datastore = require("@google-cloud/datastore");
-import bodyParser = require("body-parser");
+import Datastore = require('@google-cloud/datastore');
+import bodyParser = require('body-parser');
 
 export default function routes(redis?: Redis, credentials?) {
   const datastore = new Datastore(credentials ? { credentials } : undefined);
@@ -36,17 +36,17 @@ export default function routes(redis?: Redis, credentials?) {
 
   const router = express.Router();
   router.use(bodyParser.json());
-  const key = (req) => `/howDense?${req.query.id || ""}`.toLowerCase();
+  const key = req => `/howDense?${req.query.id || ''}`.toLowerCase();
 
   router.get(
-    "/howDense",
+    '/howDense',
     cache(key, redis),
     asyncify(async (req, res) => {
       try {
         const query = await (req.query.id
           ? db.howDense(req.query.id)
           : db.howDense());
-        const data = JSON.stringify(query.map((v) => v.result));
+        const data = JSON.stringify(query.map(v => v.result));
 
         if (redis) {
           redis.setex(key(req), 60, data);
@@ -60,7 +60,7 @@ export default function routes(redis?: Redis, credentials?) {
   );
 
   router.get(
-    "/gymHowDense",
+    '/gymHowDense',
     asyncify(async (req, res) => {
       try {
         const queryResult = await (req.query.id
@@ -84,11 +84,11 @@ export default function routes(redis?: Redis, credentials?) {
    * }
    */
   router.post(
-    "/updateLiveAverages",
+    '/updateLiveAverages',
     asyncify(async (req, res) => {
       try {
         await updateLiveAverages(req.query.id, req.query.day, req.body);
-        res.status(200).send({ success: "true" });
+        res.status(200).send({ success: 'true' });
       } catch (err) {
         res.status(400).send({ success: false, error: err.message });
       }
@@ -96,12 +96,12 @@ export default function routes(redis?: Redis, credentials?) {
   );
 
   router.get(
-    "/getGymAverages",
+    '/getGymAverages',
     asyncify(async (req, res) => {
       try {
-        const id = req.query.id || "";
-        const day = req.query.day || "";
-        const dayFormat = moment().set("day", day).format("dddd") || day;
+        const id = req.query.id || '';
+        const day = req.query.day || '';
+        const dayFormat = moment().set('day', day).format('dddd') || day;
         const result = await getHistoricalAverages(id, dayFormat);
         res.status(200).send(result);
       } catch (err) {

--- a/src/v1/density/routes.ts
+++ b/src/v1/density/routes.ts
@@ -17,7 +17,6 @@
 
 import * as express from 'express';
 import { Redis } from 'ioredis';
-import * as moment from 'moment';
 import asyncify from '../lib/asyncify';
 import { DensityDB } from './db';
 import { cache } from '../lib/cache';
@@ -101,8 +100,7 @@ export default function routes(redis?: Redis, credentials?) {
       try {
         const id = req.query.id || '';
         const day = req.query.day || '';
-        const dayFormat = moment().set('day', day).format('dddd') || day;
-        const result = await getHistoricalAverages(id, dayFormat);
+        const result = await getHistoricalAverages(id, day);
         res.status(200).send(result);
       } catch (err) {
         res.status(400).send({ success: false, error: err.message });

--- a/src/v1/facilities/db.ts
+++ b/src/v1/facilities/db.ts
@@ -1,24 +1,24 @@
-import { firebaseDB } from '../auth';
-import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from '../mapping';
-import { FacilityHourSet, FacilityInfo } from './models/info';
-import { CampusLocation } from '../models/campus';
-import { DBQuery, DB, DatabaseQueryNoParams } from '../db';
-import { FacilityMetadata } from './models/list';
-import { FacilityHours, DailyHours } from './models/hours';
+import { firebaseDB } from "../auth";
+import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from "../mapping";
+import { FacilityHourSet, FacilityInfo } from "./models/info";
+import { CampusLocation } from "../models/campus";
+import { DBQuery, DB, DatabaseQueryNoParams } from "../db";
+import { FacilityMetadata } from "./models/list";
+import { FacilityHours, DailyHours } from "./models/hours";
 
-import moment = require('moment');
-require('moment-timezone');
+import moment = require("moment");
+require("moment-timezone");
 
-moment.tz.setDefault('America/New_York');
+moment.tz.setDefault("America/New_York");
 
 function getInfo(id: string, hours: FacilityInfoDocument[]): FacilityInfo {
   const date = Math.floor(Date.now() / 1000);
 
-  const facilityHours: FacilityInfoDocument = hours.find(x => x.id === id);
+  const facilityHours: FacilityInfoDocument = hours.find((x) => x.id === id);
 
   if (facilityHours && facilityHours.operatingHours) {
     const nextClosing = facilityHours.operatingHours.find(
-      e => e.startTimestamp < date && e.endTimestamp > date
+      (e) => e.startTimestamp < date && e.endTimestamp > date
     );
 
     const nextClosingTimestamp = nextClosing ? nextClosing.endTimestamp : -1;
@@ -42,7 +42,7 @@ function getInfo(id: string, hours: FacilityInfoDocument[]): FacilityInfo {
       isOpen: nextClosingTimestamp !== -1,
       description: facilityHours.description,
       closingAt: nextClosingTimestamp,
-      dailyHours: facilityHours.operatingHours
+      dailyHours: facilityHours.operatingHours,
     });
   }
   return null;
@@ -75,7 +75,7 @@ function getHoursInfo(
               dayOfWeek: facilityHours.dayOfWeek,
               status: facilityHours.status,
               statusText: facilityHours.statusText,
-              dailyHours: facilityHours.dailyHours
+              dailyHours: facilityHours.dailyHours,
             })
           );
         }
@@ -84,7 +84,7 @@ function getHoursInfo(
   }
   return FacilityHours.assign({
     id: facilityId,
-    hours: validDailyHours
+    hours: validDailyHours,
   });
 }
 
@@ -109,7 +109,7 @@ export class FacilityDB extends DB {
     facilityId?: string
   ): Promise<DBQuery<string, FacilityInfo>[]> {
     const { datastore } = this;
-    const query = datastore.createQuery('hours');
+    const query = datastore.createQuery("hours");
 
     try {
       const [hours] = await datastore.runQuery(query);
@@ -125,9 +125,9 @@ export class FacilityDB extends DB {
         throw new Error(`Invalid ID: ${id}`);
       } else {
         return Object.keys(ID_MAP)
-          .map(id => getInfo(id, hours))
-          .filter(obj => obj != null)
-          .map(info => DB.query(info));
+          .map((id) => getInfo(id, hours))
+          .filter((obj) => obj != null)
+          .map((info) => DB.query(info));
       }
     } catch (err) {
       console.log(err.message);
@@ -140,11 +140,11 @@ export class FacilityDB extends DB {
   ): /* eslint-disable-line class-methods-use-this */ Promise<
     DatabaseQueryNoParams<FacilityMetadata>[]
   > {
-    return Object.keys(facilityListType).map(key =>
+    return Object.keys(facilityListType).map((key) =>
       DB.query(
         FacilityMetadata.assign({
           displayName: facilityListType[key],
-          id: key
+          id: key,
         })
       )
     );
@@ -154,22 +154,22 @@ export class FacilityDB extends DB {
   async efacilityList(): /* eslint-disable-line class-methods-use-this */ Promise<
     DatabaseQueryNoParams<FacilityMetadata>[]
   > {
-    return Object.keys(DISPLAY_MAP).map(key =>
+    return Object.keys(DISPLAY_MAP).map((key) =>
       DB.query(
         FacilityMetadata.assign({
           displayName: DISPLAY_MAP[key],
-          id: key
+          id: key,
         })
       )
     );
   }
 
   async gymFacilityList(): Promise<DatabaseQueryNoParams<FacilityMetadata>[]> {
-    return Object.keys(GYM_DISPLAY_MAP).map(key =>
+    return Object.keys(GYM_DISPLAY_MAP).map((key) =>
       DB.query(
         FacilityMetadata.assign({
           displayName: DISPLAY_MAP[key],
-          id: key
+          id: key,
         })
       )
     );
@@ -181,7 +181,7 @@ export class FacilityDB extends DB {
     endDate?: string
   ): Promise<DBQuery<string, FacilityHours>[]> {
     const { datastore } = this;
-    const query = datastore.createQuery('development-testing-hours');
+    const query = datastore.createQuery("development-testing-hours");
     try {
       const [hoursrange] = await datastore.runQuery(query);
       if (facilityId) {
@@ -202,9 +202,9 @@ export class FacilityDB extends DB {
       } else {
         if (startDate && endDate) {
           return Object.keys(ID_MAP)
-            .map(id => getHoursInfo(id, hoursrange, startDate, endDate))
-            .filter(obj => obj != null)
-            .map(info => DB.query(info));
+            .map((id) => getHoursInfo(id, hoursrange, startDate, endDate))
+            .filter((obj) => obj != null)
+            .map((info) => DB.query(info));
         }
         throw new Error(`Missing start and/or end date`);
       }
@@ -217,11 +217,11 @@ export class FacilityDB extends DB {
   async gymFacilityHours(facilityId?: string, date?: string) {
     if (facilityId) {
       return (
-        await firebaseDB.collection('gymdata').doc(facilityId).get()
+        await firebaseDB.collection("gymdata").doc(facilityId).get()
       ).data();
     }
     const data = [];
-    const queryResult = await firebaseDB.collection('gymdata').get();
+    const queryResult = await firebaseDB.collection("gymdata").get();
     for (const doc of queryResult.docs) {
       const docData = doc.data();
       docData.id = doc.id;

--- a/src/v1/facilities/db.ts
+++ b/src/v1/facilities/db.ts
@@ -1,24 +1,24 @@
-import { firebaseDB } from "../auth";
-import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from "../mapping";
-import { FacilityHourSet, FacilityInfo } from "./models/info";
-import { CampusLocation } from "../models/campus";
-import { DBQuery, DB, DatabaseQueryNoParams } from "../db";
-import { FacilityMetadata } from "./models/list";
-import { FacilityHours, DailyHours } from "./models/hours";
+import { firebaseDB } from '../auth';
+import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from '../mapping';
+import { FacilityHourSet, FacilityInfo } from './models/info';
+import { CampusLocation } from '../models/campus';
+import { DBQuery, DB, DatabaseQueryNoParams } from '../db';
+import { FacilityMetadata } from './models/list';
+import { FacilityHours, DailyHours } from './models/hours';
 
-import moment = require("moment");
-require("moment-timezone");
+import moment = require('moment');
+require('moment-timezone');
 
-moment.tz.setDefault("America/New_York");
+moment.tz.setDefault('America/New_York');
 
 function getInfo(id: string, hours: FacilityInfoDocument[]): FacilityInfo {
   const date = Math.floor(Date.now() / 1000);
 
-  const facilityHours: FacilityInfoDocument = hours.find((x) => x.id === id);
+  const facilityHours: FacilityInfoDocument = hours.find(x => x.id === id);
 
   if (facilityHours && facilityHours.operatingHours) {
     const nextClosing = facilityHours.operatingHours.find(
-      (e) => e.startTimestamp < date && e.endTimestamp > date
+      e => e.startTimestamp < date && e.endTimestamp > date
     );
 
     const nextClosingTimestamp = nextClosing ? nextClosing.endTimestamp : -1;
@@ -42,7 +42,7 @@ function getInfo(id: string, hours: FacilityInfoDocument[]): FacilityInfo {
       isOpen: nextClosingTimestamp !== -1,
       description: facilityHours.description,
       closingAt: nextClosingTimestamp,
-      dailyHours: facilityHours.operatingHours,
+      dailyHours: facilityHours.operatingHours
     });
   }
   return null;
@@ -75,7 +75,7 @@ function getHoursInfo(
               dayOfWeek: facilityHours.dayOfWeek,
               status: facilityHours.status,
               statusText: facilityHours.statusText,
-              dailyHours: facilityHours.dailyHours,
+              dailyHours: facilityHours.dailyHours
             })
           );
         }
@@ -84,7 +84,7 @@ function getHoursInfo(
   }
   return FacilityHours.assign({
     id: facilityId,
-    hours: validDailyHours,
+    hours: validDailyHours
   });
 }
 
@@ -109,7 +109,7 @@ export class FacilityDB extends DB {
     facilityId?: string
   ): Promise<DBQuery<string, FacilityInfo>[]> {
     const { datastore } = this;
-    const query = datastore.createQuery("hours");
+    const query = datastore.createQuery('hours');
 
     try {
       const [hours] = await datastore.runQuery(query);
@@ -125,9 +125,9 @@ export class FacilityDB extends DB {
         throw new Error(`Invalid ID: ${id}`);
       } else {
         return Object.keys(ID_MAP)
-          .map((id) => getInfo(id, hours))
-          .filter((obj) => obj != null)
-          .map((info) => DB.query(info));
+          .map(id => getInfo(id, hours))
+          .filter(obj => obj != null)
+          .map(info => DB.query(info));
       }
     } catch (err) {
       console.log(err.message);
@@ -140,11 +140,11 @@ export class FacilityDB extends DB {
   ): /* eslint-disable-line class-methods-use-this */ Promise<
     DatabaseQueryNoParams<FacilityMetadata>[]
   > {
-    return Object.keys(facilityListType).map((key) =>
+    return Object.keys(facilityListType).map(key =>
       DB.query(
         FacilityMetadata.assign({
           displayName: facilityListType[key],
-          id: key,
+          id: key
         })
       )
     );
@@ -154,22 +154,22 @@ export class FacilityDB extends DB {
   async efacilityList(): /* eslint-disable-line class-methods-use-this */ Promise<
     DatabaseQueryNoParams<FacilityMetadata>[]
   > {
-    return Object.keys(DISPLAY_MAP).map((key) =>
+    return Object.keys(DISPLAY_MAP).map(key =>
       DB.query(
         FacilityMetadata.assign({
           displayName: DISPLAY_MAP[key],
-          id: key,
+          id: key
         })
       )
     );
   }
 
   async gymFacilityList(): Promise<DatabaseQueryNoParams<FacilityMetadata>[]> {
-    return Object.keys(GYM_DISPLAY_MAP).map((key) =>
+    return Object.keys(GYM_DISPLAY_MAP).map(key =>
       DB.query(
         FacilityMetadata.assign({
           displayName: DISPLAY_MAP[key],
-          id: key,
+          id: key
         })
       )
     );
@@ -181,7 +181,7 @@ export class FacilityDB extends DB {
     endDate?: string
   ): Promise<DBQuery<string, FacilityHours>[]> {
     const { datastore } = this;
-    const query = datastore.createQuery("development-testing-hours");
+    const query = datastore.createQuery('development-testing-hours');
     try {
       const [hoursrange] = await datastore.runQuery(query);
       if (facilityId) {
@@ -202,9 +202,9 @@ export class FacilityDB extends DB {
       } else {
         if (startDate && endDate) {
           return Object.keys(ID_MAP)
-            .map((id) => getHoursInfo(id, hoursrange, startDate, endDate))
-            .filter((obj) => obj != null)
-            .map((info) => DB.query(info));
+            .map(id => getHoursInfo(id, hoursrange, startDate, endDate))
+            .filter(obj => obj != null)
+            .map(info => DB.query(info));
         }
         throw new Error(`Missing start and/or end date`);
       }
@@ -217,11 +217,11 @@ export class FacilityDB extends DB {
   async gymFacilityHours(facilityId?: string, date?: string) {
     if (facilityId) {
       return (
-        await firebaseDB.collection("gymdata").doc(facilityId).get()
+        await firebaseDB.collection('gymdata').doc(facilityId).get()
       ).data();
     }
     const data = [];
-    const queryResult = await firebaseDB.collection("gymdata").get();
+    const queryResult = await firebaseDB.collection('gymdata').get();
     for (const doc of queryResult.docs) {
       const docData = doc.data();
       docData.id = doc.id;

--- a/src/v1/facilities/routes.ts
+++ b/src/v1/facilities/routes.ts
@@ -1,13 +1,13 @@
-import * as express from 'express';
+import * as express from "express";
 // eslint-disable-line @typescript-eslint/no-var-requires
-import { Redis } from 'ioredis';
-import { addListener } from 'cluster';
-import { FacilityDB } from './db';
-import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from '../mapping';
-import asyncify from '../lib/asyncify';
-import { cache } from '../lib/cache';
+import { Redis } from "ioredis";
+import { addListener } from "cluster";
+import { FacilityDB } from "./db";
+import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from "../mapping";
+import asyncify from "../lib/asyncify";
+import { cache } from "../lib/cache";
 
-import Datastore = require('@google-cloud/datastore');
+import Datastore = require("@google-cloud/datastore");
 
 export default function routes(redis?: Redis, credentials?) {
   const datastore = new Datastore(credentials ? { credentials } : undefined);
@@ -16,12 +16,12 @@ export default function routes(redis?: Redis, credentials?) {
   const router = express.Router();
 
   router.get(
-    '/facilityList',
+    "/facilityList",
     cache(() => `/facilityList`, redis),
     asyncify(async (req: express.Request, res: express.Response) => {
       try {
         const facilityList = await db.facilityList(DISPLAY_MAP);
-        const data = JSON.stringify(facilityList.map(v => v.result));
+        const data = JSON.stringify(facilityList.map((v) => v.result));
 
         if (redis) {
           redis.setex(`/facilityList`, 60 * 10, data);
@@ -36,33 +36,36 @@ export default function routes(redis?: Redis, credentials?) {
   );
 
   router.get(
-    '/gymFacilityList',
+    "/gymFacilityList",
     cache(() => `/gymFacilityList`, redis),
     asyncify(async (req, res) => {
       try {
         const gymFacilityList = await db.facilityList(GYM_DISPLAY_MAP);
-        const data = JSON.stringify(gymFacilityList.map(v => v.result));
+        const data = JSON.stringify(gymFacilityList.map((v) => v.result));
 
         if (redis) {
-          redis.setex(`/gymFacilityList`, 60 * 10, data)
+          redis.setex(`/gymFacilityList`, 60 * 10, data);
         }
 
-        res.status(200).send(data)
+        res.status(200).send(data);
       } catch (err) {
-        res.status(400).send(err)
+        res.status(400).send(err);
       }
     })
-  )
+  );
 
-  const facilityInfoKey = req => (req.query.id ? `/facilityInfo?${req.query.id}` : `/facilityInfo`);
+  const facilityInfoKey = (req) =>
+    req.query.id ? `/facilityInfo?${req.query.id}` : `/facilityInfo`;
 
   router.get(
-    '/facilityInfo',
+    "/facilityInfo",
     cache(facilityInfoKey, redis),
     asyncify(async (req: express.Request, res: express.Response) => {
       try {
-        const facilityInfo = await (req.query.id ? db.facilityInfo(req.query.id) : db.facilityInfo());
-        const data = JSON.stringify(facilityInfo.map(v => v.result));
+        const facilityInfo = await (req.query.id
+          ? db.facilityInfo(req.query.id)
+          : db.facilityInfo());
+        const data = JSON.stringify(facilityInfo.map((v) => v.result));
 
         if (redis) {
           redis.setex(facilityInfoKey(req), 30, data);
@@ -75,16 +78,22 @@ export default function routes(redis?: Redis, credentials?) {
     })
   );
 
-  const facilityHoursKey = req =>
-    `/facilityHours?${req.query.id || ''}${`&${req.query.startDate}` || ''}${`&${req.query.endDate}` || ''}`;
+  const facilityHoursKey = (req) =>
+    `/facilityHours?${req.query.id || ""}${`&${req.query.startDate}` || ""}${
+      `&${req.query.endDate}` || ""
+    }`;
 
   router.get(
-    '/facilityHours',
+    "/facilityHours",
     cache(facilityHoursKey, redis),
     asyncify(async (req, res) => {
       try {
-        const facilityHours = await db.facilityHours(req.query.id, req.query.startDate, req.query.endDate);
-        const data = JSON.stringify(facilityHours.map(v => v.result));
+        const facilityHours = await db.facilityHours(
+          req.query.id,
+          req.query.startDate,
+          req.query.endDate
+        );
+        const data = JSON.stringify(facilityHours.map((v) => v.result));
 
         if (redis) {
           redis.setex(facilityHoursKey(req), 60 * 10, data);
@@ -99,23 +108,25 @@ export default function routes(redis?: Redis, credentials?) {
   );
 
   router.get(
-    '/gymFacilityHours',
+    "/gymFacilityHours",
     asyncify(async (req, res) => {
       try {
-        const gymFacilityHours = await db.gymFacilityHours(req.query.id, req.query.date);
-        const data = JSON.stringify(gymFacilityHours)
+        const gymFacilityHours = await db.gymFacilityHours(
+          req.query.id,
+          req.query.date
+        );
+        const data = JSON.stringify(gymFacilityHours);
         if (redis) {
           redis.setex(facilityHoursKey(req), 60 * 10, data);
         }
 
         res.status(200).send(data);
-      }
-      catch (err) {
+      } catch (err) {
         // TODO Send actual error codes based on errors. (this applies to all routes)
         res.status(400).send(err.message);
       }
     })
-  )
+  );
 
   return router;
 }

--- a/src/v1/facilities/routes.ts
+++ b/src/v1/facilities/routes.ts
@@ -1,13 +1,13 @@
-import * as express from "express";
+import * as express from 'express';
 // eslint-disable-line @typescript-eslint/no-var-requires
-import { Redis } from "ioredis";
-import { addListener } from "cluster";
-import { FacilityDB } from "./db";
-import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from "../mapping";
-import asyncify from "../lib/asyncify";
-import { cache } from "../lib/cache";
+import { Redis } from 'ioredis';
+import { addListener } from 'cluster';
+import { FacilityDB } from './db';
+import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from '../mapping';
+import asyncify from '../lib/asyncify';
+import { cache } from '../lib/cache';
 
-import Datastore = require("@google-cloud/datastore");
+import Datastore = require('@google-cloud/datastore');
 
 export default function routes(redis?: Redis, credentials?) {
   const datastore = new Datastore(credentials ? { credentials } : undefined);
@@ -16,12 +16,12 @@ export default function routes(redis?: Redis, credentials?) {
   const router = express.Router();
 
   router.get(
-    "/facilityList",
+    '/facilityList',
     cache(() => `/facilityList`, redis),
     asyncify(async (req: express.Request, res: express.Response) => {
       try {
         const facilityList = await db.facilityList(DISPLAY_MAP);
-        const data = JSON.stringify(facilityList.map((v) => v.result));
+        const data = JSON.stringify(facilityList.map(v => v.result));
 
         if (redis) {
           redis.setex(`/facilityList`, 60 * 10, data);
@@ -36,12 +36,12 @@ export default function routes(redis?: Redis, credentials?) {
   );
 
   router.get(
-    "/gymFacilityList",
+    '/gymFacilityList',
     cache(() => `/gymFacilityList`, redis),
     asyncify(async (req, res) => {
       try {
         const gymFacilityList = await db.facilityList(GYM_DISPLAY_MAP);
-        const data = JSON.stringify(gymFacilityList.map((v) => v.result));
+        const data = JSON.stringify(gymFacilityList.map(v => v.result));
 
         if (redis) {
           redis.setex(`/gymFacilityList`, 60 * 10, data);
@@ -54,18 +54,18 @@ export default function routes(redis?: Redis, credentials?) {
     })
   );
 
-  const facilityInfoKey = (req) =>
+  const facilityInfoKey = req =>
     req.query.id ? `/facilityInfo?${req.query.id}` : `/facilityInfo`;
 
   router.get(
-    "/facilityInfo",
+    '/facilityInfo',
     cache(facilityInfoKey, redis),
     asyncify(async (req: express.Request, res: express.Response) => {
       try {
         const facilityInfo = await (req.query.id
           ? db.facilityInfo(req.query.id)
           : db.facilityInfo());
-        const data = JSON.stringify(facilityInfo.map((v) => v.result));
+        const data = JSON.stringify(facilityInfo.map(v => v.result));
 
         if (redis) {
           redis.setex(facilityInfoKey(req), 30, data);
@@ -78,13 +78,13 @@ export default function routes(redis?: Redis, credentials?) {
     })
   );
 
-  const facilityHoursKey = (req) =>
-    `/facilityHours?${req.query.id || ""}${`&${req.query.startDate}` || ""}${
-      `&${req.query.endDate}` || ""
+  const facilityHoursKey = req =>
+    `/facilityHours?${req.query.id || ''}${`&${req.query.startDate}` || ''}${
+      `&${req.query.endDate}` || ''
     }`;
 
   router.get(
-    "/facilityHours",
+    '/facilityHours',
     cache(facilityHoursKey, redis),
     asyncify(async (req, res) => {
       try {
@@ -93,7 +93,7 @@ export default function routes(redis?: Redis, credentials?) {
           req.query.startDate,
           req.query.endDate
         );
-        const data = JSON.stringify(facilityHours.map((v) => v.result));
+        const data = JSON.stringify(facilityHours.map(v => v.result));
 
         if (redis) {
           redis.setex(facilityHoursKey(req), 60 * 10, data);
@@ -108,7 +108,7 @@ export default function routes(redis?: Redis, credentials?) {
   );
 
   router.get(
-    "/gymFacilityHours",
+    '/gymFacilityHours',
     asyncify(async (req, res) => {
       try {
         const gymFacilityHours = await db.gymFacilityHours(

--- a/src/v1/server.ts
+++ b/src/v1/server.ts
@@ -10,7 +10,7 @@ import Auth, { authenticated } from "./auth";
 export default function routes(redis?: Redis, credentials?) {
   const router = express.Router();
 
-  router.use("/", authenticated);
+  //router.use("/", authenticated);
   router.use(bodyParser.json());
   router.use("/", densityRoutes(redis, credentials));
   router.use("/", facilityRoutes(redis, credentials));

--- a/src/v1/server.ts
+++ b/src/v1/server.ts
@@ -1,21 +1,21 @@
-import * as express from "express";
-import * as bodyParser from "body-parser";
-import { Redis } from "ioredis";
-import densityRoutes from "./density/routes";
-import facilityRoutes from "./facilities/routes";
-import diningRoutes from "./dining/routes";
-import historicalRoutes from "./history";
-import Auth, { authenticated } from "./auth";
+import * as express from 'express';
+import * as bodyParser from 'body-parser';
+import { Redis } from 'ioredis';
+import densityRoutes from './density/routes';
+import facilityRoutes from './facilities/routes';
+import diningRoutes from './dining/routes';
+import historicalRoutes from './history';
+import Auth, { authenticated } from './auth';
 
 export default function routes(redis?: Redis, credentials?) {
   const router = express.Router();
 
-  //router.use("/", authenticated);
+  router.use("/", authenticated);
   router.use(bodyParser.json());
-  router.use("/", densityRoutes(redis, credentials));
-  router.use("/", facilityRoutes(redis, credentials));
-  router.use("/", diningRoutes(redis, credentials));
-  router.use("/", historicalRoutes(redis, credentials));
+  router.use('/', densityRoutes(redis, credentials));
+  router.use('/', facilityRoutes(redis, credentials));
+  router.use('/', diningRoutes(redis, credentials));
+  router.use('/', historicalRoutes(redis, credentials));
 
   return router;
 }


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is an update to the gyms backend.

- [x] Updated the `/gymHowDense` endpoint to pull from `/gyms` database (i.e. granular data)
- [x] Implemented error handling and more leniency for the day query to the `/getGymAverages` endpoint
- [x] Added sorting to the `/getGymAverages` endpoint

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
`/gymHowDense` should now return granular data.
![image](https://user-images.githubusercontent.com/34158284/87232680-e308d280-c38e-11ea-8033-3016f1d6fb01.png)

`/getGymAverages` should now have proper error messages, return a time-sorted list, and accept any day format understood by moment.js
![image](https://user-images.githubusercontent.com/34158284/87232737-56aadf80-c38f-11ea-96b7-9fb128af7622.png)

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
- The slight schema change for `/gymHowDense` should not affect the frontend (because it is currently unused).