### PR TITLE
Fix caching bug in /facilityHours route

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start": "node build/server.js",
     "start-no-redis": "node build/server.js --no-redis",
     "dev": "npm run build && npm run start-no-redis",
+    "dev-redis": "npm run build && npm run start",
     "lint": "eslint . --ext .js --ext .ts"
   },
   "dependencies": {

--- a/src/v1/facilities/routes.ts
+++ b/src/v1/facilities/routes.ts
@@ -67,7 +67,7 @@ export default function routes(redis?: Redis, credentials?) {
         const data = JSON.stringify(facilityInfo.map((v) => v.result));
 
         if (redis) {
-          redis.setex(facilityInfoKey(req), 30, data);
+          redis.setex(facilityInfoKey(req), 60 * 10, data);
         }
 
         res.status(200).send(data);
@@ -78,11 +78,11 @@ export default function routes(redis?: Redis, credentials?) {
   );
 
   const facilityHoursKey = (req) =>
-    generateKey(req, "/facilityHours", ["id, startDate, endDate"]);
+    generateKey(req, "/facilityHours", ["id", "startDate", "endDate"]);
   router.get(
     "/facilityHours",
     cache(facilityHoursKey, redis),
-    asyncify(async (req, res) => {
+    asyncify(async (req: express.Request, res: express.Response) => {
       try {
         const facilityHours = await db.facilityHours(
           req.query.id,


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is a bug fix for caching in `/facilityHours`.

- [x] fixed caching bug in `/facilityHours` route

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Pull and test locally with redis caching enabled (`npm run dev-redis`). You will have to start a local redis server.  
Changing the query string should now change the route's response.