### PR TITLE
Added endpoint to get wait-times

### DIFF
--- a/src/v1/server.ts
+++ b/src/v1/server.ts
@@ -2,6 +2,7 @@ import * as express from 'express';
 import * as bodyParser from 'body-parser';
 import { Redis } from 'ioredis';
 import densityRoutes from './density/routes';
+import waitTimeRoutes from './waittimes/routes';
 import facilityRoutes from './facilities/routes';
 import diningRoutes from './dining/routes';
 import historicalRoutes from './history';
@@ -34,6 +35,7 @@ export default function routes(redis?: Redis, credentials?) {
   router.use('/', facilityRoutes(redis, credentials));
   router.use('/', diningRoutes(redis, credentials));
   router.use('/', historicalRoutes(redis, credentials));
+  router.use('/', waitTimeRoutes(redis, credentials));
 
   return router;
 }

--- a/src/v1/waittimes/db.ts
+++ b/src/v1/waittimes/db.ts
@@ -1,0 +1,19 @@
+import { print } from 'util';
+// Unused right now
+import { WaitTimeDocument } from './models/waittimes';
+import { firebaseDB } from '../auth';
+
+export class WaitTimeDB {
+
+  async waitTime(facilityId?: string) {
+    if (facilityId) {
+      return (
+        await firebaseDB.collection('waittimes').doc('waittimes').get()
+      ).get(facilityId);
+    }
+    return (
+      await firebaseDB.collection('waittimes').doc('waittimes').get()
+    ).data();
+  }
+
+}

--- a/src/v1/waittimes/models/waittimes.ts
+++ b/src/v1/waittimes/models/waittimes.ts
@@ -1,0 +1,8 @@
+import { JSONParsable, JSONObject } from '../../lib/json';
+
+// Unused right now
+@JSONParsable({ id: 'string', waittime: 'number' })
+export class WaitTimeDocument extends JSONObject {
+  id: string;
+  waittime: number;
+}

--- a/src/v1/waittimes/routes.ts
+++ b/src/v1/waittimes/routes.ts
@@ -31,11 +31,11 @@ export default function routes(redis?: Redis, credentials?) {
           res.status(200).send(data);
         }
         else {
-          res.status(400).send("No such facility id.");
+          res.status(400).send({ success: false, error: "No such facility id." });
         }
       } catch (err) {
         console.log(err);
-        res.status(400).send(err);
+        res.status(400).send({ success: false, error: err.message });
       }
     })
   );

--- a/src/v1/waittimes/routes.ts
+++ b/src/v1/waittimes/routes.ts
@@ -1,0 +1,46 @@
+import * as express from 'express';
+import { Redis } from 'ioredis';
+import { WaitTimeDB } from './db';
+import asyncify from '../lib/asyncify';
+import { cache } from '../lib/cache';
+import { generateKey } from '../server';
+
+import bodyParser = require("body-parser");
+
+export default function routes(redis?: Redis, credentials?) {
+  const db = new WaitTimeDB();
+
+  const router = express.Router();
+  router.use(bodyParser.json());
+
+  const key = (req) => generateKey(req, "/waitTime", ["id"]);
+  router.get(
+    "/waitTime",
+    cache(key, redis),
+    asyncify(async (req, res) => {
+      try {
+        const query = await (req.query.id
+          ? db.waitTime(req.query.id)
+          : db.waitTime());
+
+        if (query) {
+          const data = JSON.stringify(query);
+
+          if (redis) {
+            redis.setex(key(req), 60, data);
+          }
+
+          res.status(200).send(data);
+        }
+        else {
+          res.status(400).send("No such facility id.");
+        }
+      } catch (err) {
+        console.log(err);
+        res.status(400).send(err);
+      }
+    })
+  );
+
+  return router;
+}

--- a/src/v1/waittimes/routes.ts
+++ b/src/v1/waittimes/routes.ts
@@ -19,9 +19,7 @@ export default function routes(redis?: Redis, credentials?) {
     cache(key, redis),
     asyncify(async (req, res) => {
       try {
-        const query = await (req.query.id
-          ? db.waitTime(req.query.id)
-          : db.waitTime());
+        const query = await (db.waitTime(req.query.id));
 
         if (query) {
           const data = JSON.stringify(query);


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements the /waitTime endpoint, to get wait-times for dining halls. I created a new waittimes folder for the route since we may add more routes, and this set of routes would only use the Firebase database.


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
I used Postman to test the route. There's 3 main categories of responses-

- Requesting for the wait-time for a single dining hall with a valid id
<img width="871" alt="Screen Shot 2020-11-08 at 11 32 11 AM" src="https://user-images.githubusercontent.com/24895015/98470894-a622e000-21b6-11eb-939c-6455bf1780c2.png">

- Requesting for the wait-times of every dining hall (by not including an id param)
<img width="870" alt="Screen Shot 2020-11-08 at 11 32 24 AM" src="https://user-images.githubusercontent.com/24895015/98470909-b5a22900-21b6-11eb-9e7c-d18da509afb2.png">

- Requesting for the wait-time for a dining hall with an invalid facility id
<img width="877" alt="Screen Shot 2020-11-08 at 11 32 38 AM" src="https://user-images.githubusercontent.com/24895015/98470924-c783cc00-21b6-11eb-8833-964bfbc994c4.png">

Right now the database isn't fully populated so the style of ids stored and the number of dining halls for which data is stored will change.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
Right now, the class in db.ts doesn't extend the DB class, since the Cloud datastore isn't needed for the route I implemented. Also, I made a model.ts file but haven't really used it so far since the return format of this request is pretty simple.
