### PR TITLE
Refactor routes

### DIFF
--- a/src/v1/density/routes.ts
+++ b/src/v1/density/routes.ts
@@ -15,20 +15,20 @@
  *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import * as express from "express";
-import { Redis } from "ioredis";
-import asyncify from "../lib/asyncify";
-import { DensityDB } from "./db";
-import { cache } from "../lib/cache";
+import * as express from 'express';
+import { Redis } from 'ioredis';
+import asyncify from '../lib/asyncify';
+import { DensityDB } from './db';
+import { cache } from '../lib/cache';
 import {
   getAverageSpreadsheetHistoricalData,
   updateLiveAverages,
-  getHistoricalAverages,
-} from "../data/gymHistoricalAnalysis";
-import { generateKey } from "../server";
+  getHistoricalAverages
+} from '../data/gymHistoricalAnalysis';
+import { generateKey } from '../server';
 
-import Datastore = require("@google-cloud/datastore");
-import bodyParser = require("body-parser");
+import Datastore = require('@google-cloud/datastore');
+import bodyParser = require('body-parser');
 
 export default function routes(redis?: Redis, credentials?) {
   const datastore = new Datastore(credentials ? { credentials } : undefined);
@@ -37,16 +37,16 @@ export default function routes(redis?: Redis, credentials?) {
   const router = express.Router();
   router.use(bodyParser.json());
 
-  const key = (req) => generateKey(req, "/howDense", ["id"]);
+  const key = req => generateKey(req, '/howDense', ['id']);
   router.get(
-    "/howDense",
+    '/howDense',
     cache(key, redis),
     asyncify(async (req, res) => {
       try {
         const query = await (req.query.id
           ? db.howDense(req.query.id)
           : db.howDense());
-        const data = JSON.stringify(query.map((v) => v.result));
+        const data = JSON.stringify(query.map(v => v.result));
 
         if (redis) {
           redis.setex(key(req), 60, data);
@@ -60,7 +60,7 @@ export default function routes(redis?: Redis, credentials?) {
   );
 
   router.get(
-    "/gymHowDense",
+    '/gymHowDense',
     asyncify(async (req, res) => {
       try {
         const queryResult = await (req.query.id
@@ -84,11 +84,11 @@ export default function routes(redis?: Redis, credentials?) {
    * }
    */
   router.post(
-    "/updateLiveAverages",
+    '/updateLiveAverages',
     asyncify(async (req, res) => {
       try {
         await updateLiveAverages(req.query.id, req.query.day, req.body);
-        res.status(200).send({ success: "true" });
+        res.status(200).send({ success: 'true' });
       } catch (err) {
         res.status(400).send({ success: false, error: err.message });
       }
@@ -96,11 +96,11 @@ export default function routes(redis?: Redis, credentials?) {
   );
 
   router.get(
-    "/getGymAverages",
+    '/getGymAverages',
     asyncify(async (req, res) => {
       try {
-        const id = req.query.id || "";
-        const day = req.query.day || "";
+        const id = req.query.id || '';
+        const day = req.query.day || '';
         const result = await getHistoricalAverages(id, day);
         res.status(200).send(result);
       } catch (err) {

--- a/src/v1/dining/routes.ts
+++ b/src/v1/dining/routes.ts
@@ -28,7 +28,7 @@ export default function routes(redis?: Redis, credentials?) {
     asyncify(async (req: express.Request, res: express.Response) => {
       try {
         const menuList = await db.getMenus(
-          req.query.id || req.query.facility,
+          req.query.id || req.query.facility, // TODO: Remove req.query.facility as soon as clients migrate to id
           req.query.startDate,
           req.query.endDate,
           req.query.q

--- a/src/v1/dining/routes.ts
+++ b/src/v1/dining/routes.ts
@@ -15,14 +15,20 @@ export default function routes(redis?: Redis, credentials?) {
   const router = express.Router();
 
   const menuKey = req =>
-    generateKey(req, '/menuData', ['facility', 'startDate', 'endDate', 'q']);
+    generateKey(req, '/menuData', [
+      'id',
+      'facility',
+      'startDate',
+      'endDate',
+      'q'
+    ]);
   router.get(
     '/menuData',
     cache(menuKey, redis),
     asyncify(async (req: express.Request, res: express.Response) => {
       try {
         const menuList = await db.getMenus(
-          req.query.facility,
+          req.query.id || req.query.facility,
           req.query.startDate,
           req.query.endDate,
           req.query.q

--- a/src/v1/facilities/models/hours.ts
+++ b/src/v1/facilities/models/hours.ts
@@ -1,11 +1,11 @@
-import { JSONParsable, JSONObject, typedefs, JSONArray } from "../../lib/json";
-import { FacilityHourSet } from "./info";
+import { JSONParsable, JSONObject, typedefs, JSONArray } from '../../lib/json';
+import { FacilityHourSet } from './info';
 
 @JSONParsable({
-  date: "string",
-  dayOfWeek: "number",
-  status: "number",
-  statusText: "string",
+  date: 'string',
+  dayOfWeek: 'number',
+  status: 'number',
+  statusText: 'string'
 })
 export class DailyHours extends JSONObject {
   date: string;
@@ -16,7 +16,7 @@ export class DailyHours extends JSONObject {
   dailyHours: FacilityHourSet;
 }
 
-@JSONParsable({ id: "string" })
+@JSONParsable({ id: 'string' })
 export class FacilityHours extends JSONObject {
   id: string;
   @JSONArray(DailyHours)

--- a/src/v1/facilities/models/info.ts
+++ b/src/v1/facilities/models/info.ts
@@ -2,13 +2,13 @@ import {
   JSONParsable,
   JSONObject,
   JSONObjProperty,
-  JSONEnum,
-} from "../../lib/json";
-import { CampusLocation } from "../../models/campus";
+  JSONEnum
+} from '../../lib/json';
+import { CampusLocation } from '../../models/campus';
 
 @JSONParsable({
-  startTimestamp: "number",
-  endTimestamp: "number",
+  startTimestamp: 'number',
+  endTimestamp: 'number'
 })
 export class FacilityHourSet extends JSONObject {
   startTimestamp: number;
@@ -16,10 +16,10 @@ export class FacilityHourSet extends JSONObject {
 }
 
 @JSONParsable({
-  id: "string",
-  nextOpen: "number",
-  closingAt: "number",
-  isOpen: "boolean",
+  id: 'string',
+  nextOpen: 'number',
+  closingAt: 'number',
+  isOpen: 'boolean'
 })
 export class FacilityInfo extends JSONObject {
   id: string;

--- a/src/v1/facilities/routes.ts
+++ b/src/v1/facilities/routes.ts
@@ -1,14 +1,14 @@
-import * as express from "express";
+import * as express from 'express';
 // eslint-disable-line @typescript-eslint/no-var-requires
-import { Redis } from "ioredis";
-import { addListener } from "cluster";
-import { FacilityDB } from "./db";
-import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from "../mapping";
-import asyncify from "../lib/asyncify";
-import { cache } from "../lib/cache";
-import { generateKey } from "../server";
+import { Redis } from 'ioredis';
+import { addListener } from 'cluster';
+import { FacilityDB } from './db';
+import { ID_MAP, DISPLAY_MAP, GYM_DISPLAY_MAP } from '../mapping';
+import asyncify from '../lib/asyncify';
+import { cache } from '../lib/cache';
+import { generateKey } from '../server';
 
-import Datastore = require("@google-cloud/datastore");
+import Datastore = require('@google-cloud/datastore');
 
 export default function routes(redis?: Redis, credentials?) {
   const datastore = new Datastore(credentials ? { credentials } : undefined);
@@ -17,12 +17,12 @@ export default function routes(redis?: Redis, credentials?) {
   const router = express.Router();
 
   router.get(
-    "/facilityList",
+    '/facilityList',
     cache(() => `/facilityList`, redis),
     asyncify(async (req: express.Request, res: express.Response) => {
       try {
         const facilityList = await db.facilityList(DISPLAY_MAP);
-        const data = JSON.stringify(facilityList.map((v) => v.result));
+        const data = JSON.stringify(facilityList.map(v => v.result));
 
         if (redis) {
           redis.setex(`/facilityList`, 60 * 10, data);
@@ -37,12 +37,12 @@ export default function routes(redis?: Redis, credentials?) {
   );
 
   router.get(
-    "/gymFacilityList",
+    '/gymFacilityList',
     cache(() => `/gymFacilityList`, redis),
     asyncify(async (req, res) => {
       try {
         const gymFacilityList = await db.facilityList(GYM_DISPLAY_MAP);
-        const data = JSON.stringify(gymFacilityList.map((v) => v.result));
+        const data = JSON.stringify(gymFacilityList.map(v => v.result));
 
         if (redis) {
           redis.setex(`/gymFacilityList`, 60 * 10, data);
@@ -55,16 +55,16 @@ export default function routes(redis?: Redis, credentials?) {
     })
   );
 
-  const facilityInfoKey = (req) => generateKey(req, "/facilityInfo", ["id"]);
+  const facilityInfoKey = req => generateKey(req, '/facilityInfo', ['id']);
   router.get(
-    "/facilityInfo",
+    '/facilityInfo',
     cache(facilityInfoKey, redis),
     asyncify(async (req: express.Request, res: express.Response) => {
       try {
         const facilityInfo = await (req.query.id
           ? db.facilityInfo(req.query.id)
           : db.facilityInfo());
-        const data = JSON.stringify(facilityInfo.map((v) => v.result));
+        const data = JSON.stringify(facilityInfo.map(v => v.result));
 
         if (redis) {
           redis.setex(facilityInfoKey(req), 30, data);
@@ -77,10 +77,10 @@ export default function routes(redis?: Redis, credentials?) {
     })
   );
 
-  const facilityHoursKey = (req) =>
-    generateKey(req, "/facilityHours", ["id, startDate, endDate"]);
+  const facilityHoursKey = req =>
+    generateKey(req, '/facilityHours', ['id, startDate, endDate']);
   router.get(
-    "/facilityHours",
+    '/facilityHours',
     cache(facilityHoursKey, redis),
     asyncify(async (req, res) => {
       try {
@@ -89,7 +89,7 @@ export default function routes(redis?: Redis, credentials?) {
           req.query.startDate,
           req.query.endDate
         );
-        const data = JSON.stringify(facilityHours.map((v) => v.result));
+        const data = JSON.stringify(facilityHours.map(v => v.result));
 
         if (redis) {
           redis.setex(facilityHoursKey(req), 60 * 10, data);
@@ -104,7 +104,7 @@ export default function routes(redis?: Redis, credentials?) {
   );
 
   router.get(
-    "/gymFacilityHours",
+    '/gymFacilityHours',
     asyncify(async (req, res) => {
       try {
         const gymFacilityHours = await db.gymFacilityHours(

--- a/src/v1/facilities/routes.ts
+++ b/src/v1/facilities/routes.ts
@@ -78,7 +78,7 @@ export default function routes(redis?: Redis, credentials?) {
   );
 
   const facilityHoursKey = req =>
-    generateKey(req, '/facilityHours', ['id, startDate, endDate']);
+    generateKey(req, '/facilityHours', ['id', 'startDate', 'endDate']);
   router.get(
     '/facilityHours',
     cache(facilityHoursKey, redis),

--- a/src/v1/server.ts
+++ b/src/v1/server.ts
@@ -28,7 +28,7 @@ export function generateKey(
 export default function routes(redis?: Redis, credentials?) {
   const router = express.Router();
 
-  router.use("/", authenticated);
+  router.use('/', authenticated);
   router.use(bodyParser.json());
   router.use('/', densityRoutes(redis, credentials));
   router.use('/', facilityRoutes(redis, credentials));


### PR DESCRIPTION
This is a small PR that fixes some consistency issues (as pointed out by Andrew on issue #46). Essentially, we are now using `id` instead of `facility` for indicating the dining hall on the `/menuData` route, although for now both are supported. 

Resolves #46 
