### PR TITLE
Fixed timezone bug in /feedback

### DIFF
--- a/src/v1/feedback/db.ts
+++ b/src/v1/feedback/db.ts
@@ -1,6 +1,7 @@
 import { firebaseDB } from '../auth';
 import { Feedback, FluxFeedback } from './models/feedback';
 import { DISPLAY_MAP } from '../mapping';
+import { print } from 'util';
 
 export class FeedbackDB {
   num_to_day = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
@@ -127,7 +128,7 @@ export class FeedbackDB {
 
   // POST feedback
   async addFeedback(feedback: Feedback) {
-    const time = new Date();
+    const time = new Date(new Date().toLocaleString("en-US", { timeZone: "America/New_York" }));
     const day = this.num_to_day[time.getDay()];
     const hour = time.getHours();
 

--- a/src/v1/feedback/db.ts
+++ b/src/v1/feedback/db.ts
@@ -1,7 +1,6 @@
 import { firebaseDB } from '../auth';
 import { Feedback, FluxFeedback } from './models/feedback';
 import { DISPLAY_MAP } from '../mapping';
-import { print } from 'util';
 
 export class FeedbackDB {
   num_to_day = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes a bug in the route for posting user feedback. In the Firestore, the feedback needs to be posted at a location depending on the day and hour the POST request was sent at. Since our Heroku server could be located in a different timezone, this was initially causing discrepancies. This was fixed by ensuring that the Date object is always using New York time.

### Test Plan <!-- Required -->
Tested by-

- [x] Running locally and posting feedback, then checking if it was stored at the right hour
- [x] Changing the time zone it was converted to, to make sure that the conversion function is actually doing something

<!-- Provide screenshots or point out the additional unit tests -->



