### PR TITLE
Fixed observedWait bug in /feedback

### DIFF
--- a/src/v1/feedback/routes.ts
+++ b/src/v1/feedback/routes.ts
@@ -50,6 +50,10 @@ export default function routes(redis?: Redis) {
         success: false,
         message: 'Feedback must contain observedWait field'
       });
+      if (!data.eatery) res.status(400).send({
+        success: false,
+        message: 'Feedback must contain the eatery field'
+      });
       await db
         .addFeedback(data)
         .then(() => {

--- a/src/v1/feedback/routes.ts
+++ b/src/v1/feedback/routes.ts
@@ -46,6 +46,10 @@ export default function routes(redis?: Redis) {
     '/addFeedback',
     asyncify(async (req: express.Request, res: express.Response) => {
       const data = req.body;
+      if (!data.observedWait) res.status(400).send({
+        success: false,
+        message: 'Feedback must contain observedWait field'
+      });
       await db
         .addFeedback(data)
         .then(() => {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes a bug in the /addFeedback POST request. Initially, observedWait was not a required field in the request body, hence the average feedback value in the Firestore would become NaN if no observedWait value was included.

This has been fixed so that an error message is returned if no observedWait field is included in a POST request.
### Test Plan <!-- Required -->

I tested the routes by running locally and sending requests through Postman. Here are the results of sending an invalid and valid /addFeedback request.
<img width="850" alt="Screen Shot 2021-03-21 at 3 05 56 PM" src="https://user-images.githubusercontent.com/24895015/111917658-a5009a00-8a57-11eb-97ff-f7ce61c81d10.png">
<img width="851" alt="Screen Shot 2021-03-21 at 3 06 12 PM" src="https://user-images.githubusercontent.com/24895015/111917661-aa5de480-8a57-11eb-83a0-0874e9ef1515.png">



